### PR TITLE
Hardening: unificar correo de soporte

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,5 +3,5 @@ window.KINECHECK_CONFIG = Object.freeze({
   supabaseAnonKey: "sb_publishable_FTwhDZYCF3zf7W9rB7bFwQ_rF9Y7OX_",
   courseSlug: "comunicacion-clinica",
   courseKeyFunction: "course-key",
-  supportEmail: "emmanuelkine@gmail.com",
+  supportEmail: "soporte.kinecheck@gmail.com",
 });

--- a/traumatologia/config.js
+++ b/traumatologia/config.js
@@ -3,5 +3,5 @@ window.KINECHECK_CONFIG = Object.freeze({
   supabaseAnonKey: "sb_publishable_FTwhDZYCF3zf7W9rB7bFwQ_rF9Y7OX_",
   courseSlug: "traumatologia-ortopedia-clinica",
   courseKeyFunction: "course-key",
-  supportEmail: "emmanuelkine@gmail.com",
+  supportEmail: "soporte.kinecheck@gmail.com",
 });


### PR DESCRIPTION
## Objetivo
Unifica el correo visible de soporte en dos accesos que todavía mostraban el correo personal.

## Cambios
- `config.js`: usa `soporte.kinecheck@gmail.com`.
- `traumatologia/config.js`: usa `soporte.kinecheck@gmail.com`.

## Alcance
- No modifica autenticación, licencias, webhooks, Supabase ni contenido de cursos.
- No incluye claves ni secretos.
- Queda como borrador para probar ambos accesos antes de fusionar y publicar.

## QA requerido
- Abrir Comunicación Clínica y provocar un mensaje de ayuda controlado.
- Abrir Traumatología y confirmar el correo mostrado.
- Revisar computador y teléfono.
