### PR TITLE
fix(academy): estabilizar navegación por hash e historial

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,51 @@
+# KineCheck — instrucciones para GitHub Copilot
+
+## Contexto del proyecto
+KineCheck es un ecosistema web de educación y acompañamiento musculoesquelético con tres productos separados:
+
+- `kinecheck-clinico`: profesionales.
+- `kinecheck-estudiante`: estudiantes.
+- `kinecheck-recupera`: personas en recuperación.
+
+El repositorio se publica mediante Cloudflare Pages y utiliza Supabase/servicios de backend para autenticación, licencias y acceso.
+
+## Reglas obligatorias de seguridad
+
+1. Nunca incluir secretos, claves privadas, service-role keys, tokens, contraseñas, refresh tokens ni credenciales en HTML, JavaScript del navegador, commits, logs o mensajes de error.
+2. No confiar en datos enviados por el cliente para autorizar acceso. La autorización debe validarse en el servidor.
+3. La vigencia de acceso depende de usuario autenticado, `course_slug` correcto y `active = true`. `warranty_date` no debe controlar el acceso.
+4. Mantener los bloqueos por cancelación, contracargo o reembolso.
+5. No modificar usuarios, compras, productos, propietario, tester, activaciones manuales, webhooks ni secretos salvo que la tarea lo solicite explícitamente.
+6. Mantener separados los tres productos. No conceder acceso a un producto usando la licencia de otro.
+7. Para SSO, conservar el flujo seguro existente: `POST /api/license/sso`, redirección HTTP 303 y cookie segura, HttpOnly y con SameSite apropiado.
+8. No almacenar `refresh_token`, correo personal ni información sensible en `localStorage`, `sessionStorage`, `window.name` o parámetros URL.
+9. Limpiar datos temporales de autenticación después de usarlos.
+10. No debilitar CSP, CORS, encabezados de seguridad ni validaciones para “hacer funcionar” una prueba.
+
+## Forma de trabajar
+
+- Explicar primero qué archivos se modificarán y por qué.
+- Hacer cambios mínimos y focalizados.
+- Trabajar en una rama; no modificar `main` directamente.
+- No publicar ni desplegar automáticamente.
+- No borrar versiones o respaldos existentes.
+- Antes de finalizar, revisar errores, rutas afectadas y posibles regresiones.
+- Cuando la tarea involucre autenticación, licencias o pagos, proponer pruebas positivas y negativas.
+- No inventar nombres de tablas, columnas, variables de entorno o endpoints. Buscar su definición real en el repositorio.
+- Si falta información crítica, dejar un marcador explícito y no reemplazarlo con una suposición insegura.
+
+## Estándares de código
+
+- JavaScript claro, legible y compatible con el entorno actual del proyecto.
+- Validar entradas y manejar errores sin exponer información sensible.
+- Evitar duplicación y funciones excesivamente largas.
+- Mantener la interfaz en español claro, accesible y comprensible para personas no técnicas.
+- No presentar contenido como diagnóstico médico ni sustituir atención profesional.
+
+## Validación mínima antes de proponer un cambio
+
+- Verificar que Clínico, Estudiante y Recupera continúen disponibles.
+- Verificar que una licencia inactiva, reembolsada o de otro producto no autorice acceso.
+- Verificar que el propietario y los accesos autorizados existentes sigan funcionando.
+- Verificar navegación móvil y de escritorio.
+- Indicar con precisión qué se probó y qué no se pudo probar.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "github.copilot",
+    "github.copilot-chat"
+  ]
+}

--- a/academy/academy-kinecheck-v4.js
+++ b/academy/academy-kinecheck-v4.js
@@ -8,6 +8,7 @@
   let pendingScrollTarget = "";
   let recoveryToken = "";
   let renderTimer = 0;
+  let suppressNextHashEvent = false;
 
   const $ = (selector, root = document) => root.querySelector(selector);
   const $$ = (selector, root = document) => [...root.querySelectorAll(selector)];
@@ -81,6 +82,31 @@
     return VIEW_NAMES.has(raw) ? raw : "inicio";
   }
 
+  function isAuthFragment(value = "") {
+    const fragment = String(value || "").replace(/^#/, "");
+    if (!fragment) return false;
+    const params = new URLSearchParams(fragment);
+    return params.has("access_token")
+      || params.has("refresh_token")
+      || params.has("error")
+      || params.has("error_description")
+      || params.get("type") === "recovery";
+  }
+
+  function applyHash(next, historyMode = "replace") {
+    const targetHash = `#${next}`;
+    if (location.hash === targetHash) return;
+    suppressNextHashEvent = true;
+    if (historyMode === "push") {
+      history.pushState(null, "", targetHash);
+    } else {
+      history.replaceState(null, "", targetHash);
+    }
+    window.setTimeout(() => {
+      suppressNextHashEvent = false;
+    }, 0);
+  }
+
   function activateView(view, options = {}) {
     const next = normalizedView(view);
     document.body.dataset.kcView = next;
@@ -89,7 +115,7 @@
     });
 
     if (options.updateHash !== false) {
-      history.replaceState(null, "", `#${next}`);
+      applyHash(next, options.historyMode || "replace");
     }
 
     if (next === "biblioteca") {
@@ -104,6 +130,39 @@
         window.scrollTo({ top: 0, behavior: "smooth" });
       }
     });
+  }
+
+  function restoreViewFromLocation(options = {}) {
+    const currentHash = String(location.hash || "");
+    if (isAuthFragment(currentHash)) return;
+
+    const raw = currentHash.replace(/^#/, "").toLowerCase();
+    const legacyAliases = new Set(["productos", "recursos", "evidencia-semanal", "mis-cursos", "cuenta", "mi-cuenta"]);
+    const isValidHash = VIEW_NAMES.has(raw) || legacyAliases.has(raw);
+
+    if (!isValidHash) {
+      if (location.hash !== "#inicio") {
+        suppressNextHashEvent = true;
+        history.replaceState(null, "", "#inicio");
+        window.setTimeout(() => {
+          suppressNextHashEvent = false;
+        }, 0);
+      }
+      activateView("inicio", { ...options, updateHash: false, historyMode: options.historyMode || "replace" });
+      return;
+    }
+
+    const next = normalizedView(currentHash);
+    const targetHash = `#${next}`;
+    if (location.hash !== targetHash) {
+      suppressNextHashEvent = true;
+      history.replaceState(null, "", targetHash);
+      window.setTimeout(() => {
+        suppressNextHashEvent = false;
+      }, 0);
+    }
+
+    activateView(next, { ...options, updateHash: false, historyMode: options.historyMode || "replace" });
   }
 
   function markEvidenceSection() {
@@ -369,7 +428,7 @@
       if (link) {
         event.preventDefault();
         pendingScrollTarget = link.dataset.kcScrollTarget || "";
-        activateView(link.dataset.kcViewLink);
+        activateView(link.dataset.kcViewLink, { historyMode: "push" });
         document.querySelector("#academy-sidebar")?.classList.remove("open");
         const overlay = $("#sidebar-overlay");
         if (overlay) overlay.hidden = true;
@@ -381,7 +440,7 @@
       if (scroll) {
         event.preventDefault();
         pendingScrollTarget = scroll.dataset.kcScrollTarget;
-        activateView("biblioteca");
+        activateView("biblioteca", { historyMode: "push" });
         return;
       }
 
@@ -393,7 +452,7 @@
 
       const explore = event.target.closest("[data-kc-explore-product]");
       if (explore) {
-        activateView("explorar");
+        activateView("explorar", { historyMode: "push" });
         return;
       }
 
@@ -404,12 +463,24 @@
     });
 
     window.addEventListener("hashchange", () => {
-      if (!parseRecoveryCallback()) activateView(location.hash, { updateHash: false });
+      if (suppressNextHashEvent) {
+        suppressNextHashEvent = false;
+        return;
+      }
+      if (!parseRecoveryCallback()) restoreViewFromLocation({ updateHash: false, source: "hashchange" });
+    });
+
+    window.addEventListener("popstate", () => {
+      if (suppressNextHashEvent) {
+        suppressNextHashEvent = false;
+        return;
+      }
+      if (!parseRecoveryCallback()) restoreViewFromLocation({ updateHash: false, source: "popstate" });
     });
 
     $("#kc-home-continue")?.addEventListener("click", () => {
       if (!$("#continue-button")?.hidden) $("#continue-button").click();
-      else activateView("biblioteca");
+      else activateView("biblioteca", { historyMode: "push" });
     });
   }
 
@@ -445,7 +516,7 @@
     wireRecovery();
     wireNavigation();
     observeCoreState();
-    if (!isRecovery) activateView(location.hash, { updateHash: false, scroll: false });
+    if (!isRecovery) restoreViewFromLocation({ updateHash: false, scroll: false });
     refreshAll();
   }
 


### PR DESCRIPTION
Corrige la navegación interna de Academy mediante hashes estables.

Cambios:
- restaura la vista al recargar;
- permite usar atrás y adelante;
- normaliza hashes inválidos a #inicio;
- conserva alias antiguos;
- protege fragmentos de autenticación y recuperación.

Archivo modificado:
- academy/academy-kinecheck-v4.js

No modifica autenticación, SSO, Supabase, licencias, productos ni backend.