### PR TITLE
Corrige overflow móvil en fichas de producto

### DIFF
--- a/productos/product-price-v1.css
+++ b/productos/product-price-v1.css
@@ -32,7 +32,10 @@
 .mobile-cta .buy{font-weight:900}
 @media(max-width:1040px){.quick-facts{grid-template-columns:repeat(3,minmax(0,1fr))}}
 @media(max-width:700px){
-  .product-detail-price{display:grid;gap:10px;padding:17px}
+  .product-detail-price{display:grid;gap:10px;width:100%;max-width:100%;min-width:0;padding:17px}
   .product-detail-price>div{min-width:0}
-  .quick-facts{grid-template-columns:1fr 1fr}
+  .product-detail-price p,.product-detail-price small{min-width:0;max-width:100%;overflow-wrap:anywhere}
+  .pack-price-note{width:100%;max-width:100%;min-width:0;overflow-wrap:anywhere}
+  .quick-facts{grid-template-columns:1fr}
+  .quick-facts>*{min-width:0;max-width:100%}
 }


### PR DESCRIPTION
Corrige la colisión responsive detectada por Playwright en /productos/ a 390 px: la hoja dinámica de precios anulaba la cuadrícula móvil del CSS base. En <=700 px se fuerza una sola columna y se limita el bloque de precio/notas al ancho disponible.

No modifica autenticación, Supabase, webhooks, licencias, usuarios, secretos, propietario ni testers.