### PR TITLE
Endurece QA de overflow y elimina falso verde

### DIFF
--- a/.github/workflows/validate-launch-readiness-public.yml
+++ b/.github/workflows/validate-launch-readiness-public.yml
@@ -14,6 +14,7 @@ on:
       - "academy/**"
       - "platform/**"
       - "tests/launch-readiness-public.spec.mjs"
+      - "tests/product-overflow-diagnostic.mjs"
       - ".github/workflows/validate-launch-readiness-public.yml"
   workflow_dispatch:
 
@@ -38,18 +39,20 @@ jobs:
           npm init -y >/dev/null 2>&1
           npm install playwright@1.55.0 >/dev/null 2>&1
           npx playwright install --with-deps chromium >/dev/null 2>&1
+      - name: Diagnosticar overflow móvil de productos
+        env:
+          BASE_URL: https://kinecheck.cl
+        run: node tests/product-overflow-diagnostic.mjs
       - name: Esperar publicación y validar
         env:
           BASE_URL: https://kinecheck.cl
         run: |
-          last=1
           for attempt in $(seq 1 12); do
             echo "Intento ${attempt}/12"
             if node tests/launch-readiness-public.spec.mjs; then
               echo "QA pública multidispositivo aprobada." >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
-            last=$?
             sleep 10
           done
-          exit "$last"
+          exit 1

--- a/tests/product-overflow-diagnostic.mjs
+++ b/tests/product-overflow-diagnostic.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { chromium } from "playwright";
+
+const BASE = String(process.env.BASE_URL || "https://kinecheck.cl").replace(/\/$/, "");
+const browser = await chromium.launch({ headless: true });
+
+try {
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    locale: "es-CL",
+    timezoneId: "America/Santiago",
+  });
+  const page = await context.newPage();
+  await page.goto(`${BASE}/productos/?qa=overflow-${Date.now()}`, {
+    waitUntil: "networkidle",
+    timeout: 60000,
+  });
+  await page.waitForFunction(() => {
+    const title = document.querySelector("#product-title")?.textContent || "";
+    return title.includes("KineCheck Clínico") && Boolean(document.querySelector(".product-detail-price"));
+  }, { timeout: 15000 });
+
+  const result = await page.evaluate(() => {
+    const viewport = document.documentElement.clientWidth;
+    const offenders = [...document.querySelectorAll("body *")]
+      .map((el) => {
+        const rect = el.getBoundingClientRect();
+        const style = getComputedStyle(el);
+        return {
+          tag: el.tagName.toLowerCase(),
+          id: el.id || "",
+          className: typeof el.className === "string" ? el.className : "",
+          left: Math.round(rect.left * 10) / 10,
+          right: Math.round(rect.right * 10) / 10,
+          width: Math.round(rect.width * 10) / 10,
+          scrollWidth: el.scrollWidth,
+          clientWidth: el.clientWidth,
+          display: style.display,
+          position: style.position,
+          whiteSpace: style.whiteSpace,
+          text: (el.textContent || "").trim().replace(/\s+/g, " ").slice(0, 100),
+        };
+      })
+      .filter((item) => item.right > viewport + 1 || item.left < -1 || item.scrollWidth > item.clientWidth + 3)
+      .sort((a, b) => Math.max(b.right - viewport, b.scrollWidth - b.clientWidth) - Math.max(a.right - viewport, a.scrollWidth - a.clientWidth))
+      .slice(0, 25);
+
+    return {
+      viewport,
+      documentScrollWidth: document.documentElement.scrollWidth,
+      bodyScrollWidth: document.body.scrollWidth,
+      offenders,
+    };
+  });
+
+  console.log(JSON.stringify(result, null, 2));
+  assert.ok(
+    result.documentScrollWidth <= result.viewport + 3,
+    `Overflow móvil en /productos/: ${result.documentScrollWidth}/${result.viewport}`,
+  );
+  await context.close();
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
Corrige el workflow de preparación pública para que 12 intentos fallidos terminen realmente en error y añade un diagnóstico Playwright que identifica elementos responsables de overflow horizontal en /productos/ móvil.

Es QA únicamente; no modifica autenticación, Supabase, webhooks, licencias, usuarios, secretos, propietario ni testers.