### PR TITLE
Invalida caché de la corrección responsive de productos

### DIFF
--- a/productos/product-experience-unification-v1.js
+++ b/productos/product-experience-unification-v1.js
@@ -4,9 +4,9 @@
   if (window.__KC_PRODUCT_EXPERIENCE_V1__) return;
   window.__KC_PRODUCT_EXPERIENCE_V1__ = true;
 
-  const VERSION = "20260806-unified1";
+  const VERSION = "20260807-unified2";
   const slug = new URLSearchParams(location.search).get("producto") || "kinecheck-clinico";
-  const PRIVATE_URL = new URL(`../academy/?v=${VERSION}`, location.href).toString();
+  const PRIVATE_URL = new URL("../academy/", location.href).toString();
 
   function loadStyles() {
     if (document.querySelector("link[data-kc-product-unified]")) return;


### PR DESCRIPTION
Actualiza la versión del CSS dinámico de experiencia de producto a `20260807-unified2` para que producción cargue la corrección responsive recién publicada. Además, normaliza los enlaces privados reescritos por este módulo directamente a `/academy/`, sin parámetro interno de versión.

No modifica autenticación, Supabase, webhooks, licencias, usuarios, secretos, propietario ni testers.