### PR TITLE
Update regression for upcoming KineCheck Formación courses

### DIFF
--- a/tests/public-source-regression.test.mjs
+++ b/tests/public-source-regression.test.mjs
@@ -61,7 +61,10 @@ test("la arquitectura oficial de marca está explícita y es consistente", async
 
   const professionals = await read("profesionales/index.html");
   assert.equal(count(professionals, "KINECHECK APPS"), 1);
-  assert.equal(count(professionals, "KINECHECK FORMACIÓN · POR KINECHECK"), 4);
+  assert.equal(count(professionals, "KINECHECK FORMACIÓN · POR KINECHECK"), 6);
+  assert.equal(count(professionals, "PRÓXIMAMENTE"), 2);
+  assert.ok(professionals.includes("Banderas Clínicas"));
+  assert.ok(professionals.includes("Dolor Lumbar"));
 
   const students = await read("estudiantes/index.html");
   assert.equal(count(students, "KINECHECK APPS"), 1);


### PR DESCRIPTION
## Cambio
- actualiza la regresión de arquitectura de marca para reconocer seis tarjetas KineCheck Formación en Profesionales;
- valida explícitamente las dos tarjetas `PRÓXIMAMENTE`: `Banderas Clínicas` y `Dolor Lumbar`;
- mantiene la validación comercial en cinco bloques de precio, evitando tratar cursos futuros como productos vendibles.

## Alcance
- solo modifica `tests/public-source-regression.test.mjs`;
- no cambia frontend, precios, checkouts, Auth, Supabase, SSO, licencias ni datos productivos.