### PR TITLE
Fix guided Academy open buttons

### DIFF
--- a/academy/academy-brand-identity.js
+++ b/academy/academy-brand-identity.js
@@ -90,7 +90,7 @@
   loadScript("./mi-kinecheck-card-copy-v1.js", "data-mi-kinecheck-card-copy", "20260806-unified1");
   loadScript("./mi-kinecheck-simplify-v2.js", "data-mi-kinecheck-simplify-v2", "20260806-simplified3");
 
-  loadScript("./academy-recommended-buttons-fix.js", "data-kc-recommended-buttons-fix", "20260808-owned-buttons1");
+  loadScript("./academy-recommended-buttons-fix.js", "data-kc-recommended-buttons-fix", "20260808-guided-owned2");
   loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260808-owned-buttons1");
   loadScript("./academy-clinico-course-v1.js", "data-kc-clinico-course", "20260806-final5");
 

--- a/academy/academy-recommended-buttons-fix.js
+++ b/academy/academy-recommended-buttons-fix.js
@@ -7,6 +7,7 @@
   const SELECTOR = [
     "#kc-stage-recommendations [data-kc-path-open]",
     "[data-kc-open-product]",
+    "[data-kc-open-owned]",
     "#course-grid [data-course]",
   ].join(",");
   const OPENER_SRC = "./academy-open-v6.js?v=20260808-owned-buttons1";
@@ -67,6 +68,7 @@
     return String(
       button.dataset.kcPathOpen
       || button.dataset.kcOpenProduct
+      || button.dataset.kcOpenOwned
       || button.dataset.course
       || "",
     ).trim();

--- a/tests/owned-buttons.spec.mjs
+++ b/tests/owned-buttons.spec.mjs
@@ -23,6 +23,7 @@ async function installHarness(page) {
       <div id="kc-toast" hidden></div>
       <section id="home-app-grid"></section>
       <section id="home-course-grid"></section>
+      <section id="guided-route"></section>
       <section id="course-grid"></section>
     </body></html>
   `);
@@ -80,6 +81,25 @@ test("los botones de cursos en Inicio y Mis cursos abren el curso exacto", async
 
   await expect.poll(async () => page.evaluate(() => window.__openedProducts)).toEqual(
     courses.map((product) => ({ product, text: "Continuar" })),
+  );
+});
+
+test("los botones Abrir de la ruta guiada abren directamente el producto exacto", async ({ page }) => {
+  await installHarness(page);
+
+  const guidedProducts = ["kinecheck-estudiante", "kinecheck-recupera", "comunicacion-clinica"];
+  await page.evaluate((slugs) => {
+    document.querySelector("#guided-route").innerHTML = slugs.map((slug) => `
+      <article><button type="button" data-kc-open-owned="${slug}">Abrir</button></article>
+    `).join("");
+  }, guidedProducts);
+
+  for (const product of guidedProducts) {
+    await page.locator(`[data-kc-open-owned="${product}"]`).click();
+  }
+
+  await expect.poll(async () => page.evaluate(() => window.__openedProducts)).toEqual(
+    guidedProducts.map((product) => ({ product, text: "Abrir" })),
   );
 });
 


### PR DESCRIPTION
Corrige los botones `Abrir` de la ruta guiada / Mi KineCheck que usan `data-kc-open-owned` para que entren al router central `KINECHECK_OPEN_PRODUCT` igual que Mis productos, Mis cursos y Recomendado para tu etapa.

Cambios:
- el router de Academy captura también `[data-kc-open-owned]`;
- resuelve el slug directamente desde `data-kc-open-owned`;
- agrega regresión Playwright específica para botones guiados;
- actualiza el cache-bust del router en `academy-brand-identity.js`.

No modifica Auth, Supabase, SSO, licencias, webhooks, compras, usuarios ni secretos.