### PR TITLE
Fix guided buttons in primary Academy router

### DIFF
--- a/academy/academy-bootstrap-v28.js
+++ b/academy/academy-bootstrap-v28.js
@@ -306,7 +306,7 @@ window.KINECHECK_ACADEMY_CONFIG = Object.freeze({
 (() => {
   if (document.querySelector('script[data-kc-brand-identity]')) return;
   const script = document.createElement("script");
-  script.src = "./academy-brand-identity.js?v=20260802-brand1";
+  script.src = "./academy-brand-identity.js?v=20260808-guided-router3";
   script.async = false;
   script.dataset.kcBrandIdentity = "true";
   document.head.appendChild(script);

--- a/academy/academy-brand-identity.js
+++ b/academy/academy-brand-identity.js
@@ -91,7 +91,7 @@
   loadScript("./mi-kinecheck-simplify-v2.js", "data-mi-kinecheck-simplify-v2", "20260806-simplified3");
 
   loadScript("./academy-recommended-buttons-fix.js", "data-kc-recommended-buttons-fix", "20260808-guided-owned2");
-  loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260808-owned-buttons1");
+  loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260808-guided-router3");
   loadScript("./academy-clinico-course-v1.js", "data-kc-clinico-course", "20260806-final5");
 
   if (document.readyState === "loading") {

--- a/academy/academy-open-v6.js
+++ b/academy/academy-open-v6.js
@@ -228,12 +228,13 @@
   window.KINECHECK_RESET_PRODUCT_NAVIGATION = resetNavigationState;
 
   document.addEventListener("click", (event) => {
-    const button = event.target.closest("[data-course], [data-kc-path-open], [data-kc-open-product], #continue-button");
+    const button = event.target.closest("[data-course], [data-kc-path-open], [data-kc-open-product], [data-kc-open-owned], #continue-button");
     if (!button || button.disabled || button.getAttribute("aria-disabled") === "true") return;
     const product = String(
       button.dataset.course
       || button.dataset.kcPathOpen
       || button.dataset.kcOpenProduct
+      || button.dataset.kcOpenOwned
       || "",
     ).trim();
     if (!KNOWN.has(product)) return;

--- a/tests/owned-buttons.spec.mjs
+++ b/tests/owned-buttons.spec.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const FIX_SCRIPT = path.join(ROOT, "academy", "academy-recommended-buttons-fix.js");
+const OPEN_SCRIPT = path.join(ROOT, "academy", "academy-open-v6.js");
 
 const applications = ["kinecheck-estudiante", "kinecheck-recupera"];
 const courses = [
@@ -101,6 +102,41 @@ test("los botones Abrir de la ruta guiada abren directamente el producto exacto"
   await expect.poll(async () => page.evaluate(() => window.__openedProducts)).toEqual(
     guidedProducts.map((product) => ({ product, text: "Abrir" })),
   );
+});
+
+test("el router principal reconoce data-kc-open-owned y navega a la aplicación", async ({ page }) => {
+  await page.route("https://example.test/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div id="kc-toast" hidden></div>
+        <button type="button" data-kc-open-owned="kinecheck-estudiante">Abrir</button>
+      </body></html>`,
+    });
+  });
+
+  await page.goto("https://example.test/academy/");
+  await page.evaluate(() => {
+    const session = {
+      access_token: "test-access-token",
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      expires_in: 3600,
+      token_type: "bearer",
+    };
+    window.KINECHECK_ACADEMY_SESSION = {
+      get: () => session,
+      refresh: async () => session,
+    };
+  });
+  await page.addScriptTag({ path: OPEN_SCRIPT });
+
+  await page.locator('[data-kc-open-owned="kinecheck-estudiante"]').click();
+  await page.waitForURL(/app-sso-relay\.html\?product=kinecheck-estudiante/);
+
+  const url = new URL(page.url());
+  expect(url.pathname).toBe("/academy/app-sso-relay.html");
+  expect(url.searchParams.get("product")).toBe("kinecheck-estudiante");
 });
 
 test("al volver a Academy se libera cualquier estado de navegación", async ({ page }) => {


### PR DESCRIPTION
Corrige el fallo real de los botones `Abrir` en `#inicio`.

Causa encontrada: el parche auxiliar reconocía `data-kc-open-owned`, pero el router principal `academy-open-v6.js` todavía no lo reconocía. La regresión anterior simulaba `KINECHECK_OPEN_PRODUCT`, por lo que podía quedar verde sin probar el router real.

Cambios:
- `academy-open-v6.js` captura `[data-kc-open-owned]` directamente y resuelve su slug en el router principal;
- se actualiza el cache-bust del router principal y del loader de identidad;
- se agrega un E2E que carga el router principal real, pulsa `data-kc-open-owned="kinecheck-estudiante"` y exige navegación a `app-sso-relay.html?product=kinecheck-estudiante`;
- no se modifica Auth, Supabase, SSO, licencias, compras, webhooks, usuarios ni secretos.