### PR TITLE
Refresh Academy button router cache chain

### DIFF
--- a/academy/academy-brand-identity.js
+++ b/academy/academy-brand-identity.js
@@ -90,8 +90,8 @@
   loadScript("./mi-kinecheck-card-copy-v1.js", "data-mi-kinecheck-card-copy", "20260806-unified1");
   loadScript("./mi-kinecheck-simplify-v2.js", "data-mi-kinecheck-simplify-v2", "20260806-simplified3");
 
-  loadScript("./academy-recommended-buttons-fix.js", "data-kc-recommended-buttons-fix", "20260808-guided-owned2");
-  loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260808-guided-router3");
+  loadScript("./academy-recommended-buttons-fix.js", "data-kc-recommended-buttons-fix", "20260808-guided-owned3");
+  loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260808-guided-router4");
   loadScript("./academy-clinico-course-v1.js", "data-kc-clinico-course", "20260806-final5");
 
   if (document.readyState === "loading") {

--- a/academy/academy-recommended-buttons-fix.js
+++ b/academy/academy-recommended-buttons-fix.js
@@ -10,7 +10,7 @@
     "[data-kc-open-owned]",
     "#course-grid [data-course]",
   ].join(",");
-  const OPENER_SRC = "./academy-open-v6.js?v=20260808-owned-buttons1";
+  const OPENER_SRC = "./academy-open-v6.js?v=20260808-guided-router4";
   let openerPromise = null;
 
   function toast(text) {


### PR DESCRIPTION
Fuerza una nueva cadena de carga para los botones de Academy después de detectar que producción seguía sirviendo referencias internas antiguas mientras Cloudflare tenía el deploy anterior atascado.

Cambios acotados:
- `academy-recommended-buttons-fix.js` apunta al router `academy-open-v6.js?v=20260808-guided-router4`;
- `academy-brand-identity.js` carga el parche con `guided-owned3` y el router con `guided-router4`;
- no se modifica Auth, Supabase, SSO, licencias, compras, webhooks, usuarios ni secretos.

Objetivo: invalidar referencias antiguas y forzar un nuevo deployment de Cloudflare con el router correcto.