### PR TITLE
Use native Academy flow for guided buttons

### DIFF
--- a/academy/academy-bootstrap-v28.js
+++ b/academy/academy-bootstrap-v28.js
@@ -306,7 +306,7 @@ window.KINECHECK_ACADEMY_CONFIG = Object.freeze({
 (() => {
   if (document.querySelector('script[data-kc-brand-identity]')) return;
   const script = document.createElement("script");
-  script.src = "./academy-brand-identity.js?v=20260808-guided-router3";
+  script.src = "./academy-brand-identity.js?v=20260809-native-owned1";
   script.async = false;
   script.dataset.kcBrandIdentity = "true";
   document.head.appendChild(script);

--- a/academy/academy-brand-identity.js
+++ b/academy/academy-brand-identity.js
@@ -86,12 +86,12 @@
   loadScript("../assets/observability.js", "data-kc-observability", "20260807-1");
   loadScript("./security-hardening-v1.js", "data-kc-security-hardening", "20260807-1");
   loadScript("../metrics-v1.js", "data-kc-launch-metrics", "20260806-launch-metrics1");
-  loadScript("./mi-kinecheck-v1.js", "data-mi-kinecheck", "20260806-unified1");
+  loadScript("./mi-kinecheck-v1.js", "data-mi-kinecheck", "20260809-native-owned1");
   loadScript("./mi-kinecheck-card-copy-v1.js", "data-mi-kinecheck-card-copy", "20260806-unified1");
   loadScript("./mi-kinecheck-simplify-v2.js", "data-mi-kinecheck-simplify-v2", "20260806-simplified3");
 
-  loadScript("./academy-recommended-buttons-fix.js", "data-kc-recommended-buttons-fix", "20260808-guided-owned3");
-  loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260808-guided-router4");
+  loadScript("./academy-recommended-buttons-fix.js", "data-kc-recommended-buttons-fix", "20260809-native-owned1");
+  loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260809-native-owned1");
   loadScript("./academy-clinico-course-v1.js", "data-kc-clinico-course", "20260806-final5");
 
   if (document.readyState === "loading") {

--- a/academy/academy-open-v6.js
+++ b/academy/academy-open-v6.js
@@ -228,13 +228,13 @@
   window.KINECHECK_RESET_PRODUCT_NAVIGATION = resetNavigationState;
 
   document.addEventListener("click", (event) => {
-    const button = event.target.closest("[data-course], [data-kc-path-open], [data-kc-open-product], [data-kc-open-owned], #continue-button");
+    if (window.__KINECHECK_NATIVE_OWNED_PROXY__) return;
+    const button = event.target.closest("[data-course], [data-kc-path-open], [data-kc-open-product], #continue-button");
     if (!button || button.disabled || button.getAttribute("aria-disabled") === "true") return;
     const product = String(
       button.dataset.course
       || button.dataset.kcPathOpen
       || button.dataset.kcOpenProduct
-      || button.dataset.kcOpenOwned
       || "",
     ).trim();
     if (!KNOWN.has(product)) return;

--- a/academy/academy-recommended-buttons-fix.js
+++ b/academy/academy-recommended-buttons-fix.js
@@ -7,10 +7,9 @@
   const SELECTOR = [
     "#kc-stage-recommendations [data-kc-path-open]",
     "[data-kc-open-product]",
-    "[data-kc-open-owned]",
     "#course-grid [data-course]",
   ].join(",");
-  const OPENER_SRC = "./academy-open-v6.js?v=20260808-guided-router4";
+  const OPENER_SRC = "./academy-open-v6.js?v=20260809-native-owned1";
   let openerPromise = null;
 
   function toast(text) {
@@ -68,13 +67,13 @@
     return String(
       button.dataset.kcPathOpen
       || button.dataset.kcOpenProduct
-      || button.dataset.kcOpenOwned
       || button.dataset.course
       || "",
     ).trim();
   }
 
   document.addEventListener("click", async (event) => {
+    if (window.__KINECHECK_NATIVE_OWNED_PROXY__) return;
     const button = event.target.closest(SELECTOR);
     if (!button || button.disabled || button.getAttribute("aria-disabled") === "true") return;
 

--- a/academy/mi-kinecheck-v1.js
+++ b/academy/mi-kinecheck-v1.js
@@ -4,7 +4,7 @@
   if (window.__MI_KINECHECK_V1__) return;
   window.__MI_KINECHECK_V1__ = true;
 
-  const VERSION = "20260806-unified1";
+  const VERSION = "20260809-native-owned1";
   const STUDENT_ORDER = [
     ["kinecheck-estudiante", "Practica el proceso guiado", "Aprende qué preguntar, observar y relacionar antes de avanzar."],
     ["mas-alla-del-dolor", "Comprende dolor, función y contexto", "Profundiza cuando ya puedas seguir el orden básico de evaluación."],
@@ -53,7 +53,22 @@
   }
 
   function openButton(slug) {
-    return [...document.querySelectorAll(`[data-course="${slug}"]`)].find((button) => !button.disabled) || null;
+    const selector = `[data-course="${slug}"]`;
+    return [...document.querySelectorAll(`#course-grid ${selector}`)].find((button) => !button.disabled)
+      || [...document.querySelectorAll(selector)].find((button) => !button.disabled)
+      || null;
+  }
+
+  function openOwnedThroughLibrary(slug) {
+    const target = openButton(slug);
+    if (!target) return false;
+    window.__KINECHECK_NATIVE_OWNED_PROXY__ = true;
+    try {
+      target.click();
+    } finally {
+      window.__KINECHECK_NATIVE_OWNED_PROXY__ = false;
+    }
+    return true;
   }
 
   function activeSlugs() {
@@ -230,7 +245,9 @@
   document.addEventListener("click", (event) => {
     const button = event.target.closest("[data-kc-open-owned]");
     if (!button || button.disabled) return;
-    openButton(button.dataset.kcOpenOwned)?.click();
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    openOwnedThroughLibrary(button.dataset.kcOpenOwned);
   });
 
   function schedule() {

--- a/tests/owned-buttons.spec.mjs
+++ b/tests/owned-buttons.spec.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const FIX_SCRIPT = path.join(ROOT, "academy", "academy-recommended-buttons-fix.js");
 const OPEN_SCRIPT = path.join(ROOT, "academy", "academy-open-v6.js");
+const MI_SCRIPT = path.join(ROOT, "academy", "mi-kinecheck-v1.js");
 
 const applications = ["kinecheck-estudiante", "kinecheck-recupera"];
 const courses = [
@@ -85,58 +86,72 @@ test("los botones de cursos en Inicio y Mis cursos abren el curso exacto", async
   );
 });
 
-test("los botones Abrir de la ruta guiada abren directamente el producto exacto", async ({ page }) => {
-  await installHarness(page);
-
+test("los botones Abrir de la ruta guiada reutilizan el flujo nativo de Mis productos", async ({ page }) => {
   const guidedProducts = ["kinecheck-estudiante", "kinecheck-recupera", "comunicacion-clinica"];
+
+  await page.setContent(`
+    <!doctype html>
+    <html><head></head><body data-kc-experience="professional">
+      <div id="kc-toast" hidden></div>
+      <section id="dashboard-view"></section>
+      <section id="inicio"></section>
+      <section id="guided-route"></section>
+      <section id="course-grid"></section>
+    </body></html>
+  `);
+
   await page.evaluate((slugs) => {
+    window.KINECHECK_ACADEMY_CONFIG = { ownerEmails: [] };
+    window.__nativeOpenedProducts = [];
     document.querySelector("#guided-route").innerHTML = slugs.map((slug) => `
       <article><button type="button" data-kc-open-owned="${slug}">Abrir</button></article>
     `).join("");
+    document.querySelector("#course-grid").innerHTML = slugs.map((slug) => `
+      <article><button type="button" data-course="${slug}">Abrir desde biblioteca</button></article>
+    `).join("");
+    document.querySelector("#course-grid").addEventListener("click", (event) => {
+      const button = event.target.closest("[data-course]");
+      if (button && !button.disabled) window.__nativeOpenedProducts.push(button.dataset.course);
+    });
   }, guidedProducts);
 
+  await page.addScriptTag({ path: OPEN_SCRIPT });
+  await page.addScriptTag({ path: FIX_SCRIPT });
+  await page.addScriptTag({ path: MI_SCRIPT });
+
   for (const product of guidedProducts) {
-    await page.locator(`[data-kc-open-owned="${product}"]`).click();
+    await page.locator(`#guided-route [data-kc-open-owned="${product}"]`).click();
   }
 
-  await expect.poll(async () => page.evaluate(() => window.__openedProducts)).toEqual(
-    guidedProducts.map((product) => ({ product, text: "Abrir" })),
-  );
+  await expect.poll(async () => page.evaluate(() => window.__nativeOpenedProducts)).toEqual(guidedProducts);
 });
 
-test("el router principal reconoce data-kc-open-owned y navega a la aplicación", async ({ page }) => {
-  await page.route("https://example.test/**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "text/html",
-      body: `<!doctype html><html><body>
-        <div id="kc-toast" hidden></div>
-        <button type="button" data-kc-open-owned="kinecheck-estudiante">Abrir</button>
-      </body></html>`,
-    });
-  });
+test("el proxy nativo hace bypass de los routers auxiliares", async ({ page }) => {
+  await page.setContent(`
+    <!doctype html>
+    <html><head></head><body>
+      <div id="kc-toast" hidden></div>
+      <section id="course-grid"><button type="button" data-course="comunicacion-clinica">Abrir</button></section>
+    </body></html>
+  `);
 
-  await page.goto("https://example.test/academy/");
   await page.evaluate(() => {
-    const session = {
-      access_token: "test-access-token",
-      expires_at: Math.floor(Date.now() / 1000) + 3600,
-      expires_in: 3600,
-      token_type: "bearer",
-    };
-    window.KINECHECK_ACADEMY_SESSION = {
-      get: () => session,
-      refresh: async () => session,
-    };
+    window.__nativeClicks = 0;
+    document.querySelector("#course-grid").addEventListener("click", () => { window.__nativeClicks += 1; });
   });
   await page.addScriptTag({ path: OPEN_SCRIPT });
+  await page.addScriptTag({ path: FIX_SCRIPT });
 
-  await page.locator('[data-kc-open-owned="kinecheck-estudiante"]').click();
-  await page.waitForURL(/app-sso-relay\.html\?product=kinecheck-estudiante/);
+  await page.evaluate(() => {
+    window.__KINECHECK_NATIVE_OWNED_PROXY__ = true;
+    try {
+      document.querySelector('#course-grid [data-course="comunicacion-clinica"]').click();
+    } finally {
+      window.__KINECHECK_NATIVE_OWNED_PROXY__ = false;
+    }
+  });
 
-  const url = new URL(page.url());
-  expect(url.pathname).toBe("/academy/app-sso-relay.html");
-  expect(url.searchParams.get("product")).toBe("kinecheck-estudiante");
+  await expect.poll(async () => page.evaluate(() => window.__nativeClicks)).toBe(1);
 });
 
 test("al volver a Academy se libera cualquier estado de navegación", async ({ page }) => {


### PR DESCRIPTION
Corrige los botones `Abrir` de Inicio/Mi ruta reutilizando el flujo nativo de `Mis productos` en vez del router paralelo.

Cambios:
- `data-kc-open-owned` deja de ser interceptado por los routers auxiliares;
- el botón guiado busca primero el botón real correspondiente dentro de `#course-grid`;
- el clic proxy activa un bypass temporal para que llegue al listener nativo de Academy (`openCourse()`), que valida sesión/licencia y usa el SSO directo existente;
- se actualizan cache-busts y pruebas para verificar explícitamente este flujo.

No se modifica Auth, Supabase, SSO backend, licencias, compras, webhooks, usuarios ni secretos.