### PR TITLE
Use native Academy flow for Inicio buttons

### DIFF
--- a/academy/academy-open-v6.js
+++ b/academy/academy-open-v6.js
@@ -227,16 +227,13 @@
   window.KINECHECK_OPEN_PRODUCT = openProduct;
   window.KINECHECK_RESET_PRODUCT_NAVIGATION = resetNavigationState;
 
+  // Este router queda reservado a recomendaciones especiales. Los botones
+  // nativos de Inicio/Mis productos/Continuar deben llegar a Academy v39,
+  // que valida licencia y ejecuta el SSO canónico mediante openCourse().
   document.addEventListener("click", (event) => {
-    if (window.__KINECHECK_NATIVE_OWNED_PROXY__) return;
-    const button = event.target.closest("[data-course], [data-kc-path-open], [data-kc-open-product], #continue-button");
+    const button = event.target.closest("[data-kc-path-open]");
     if (!button || button.disabled || button.getAttribute("aria-disabled") === "true") return;
-    const product = String(
-      button.dataset.course
-      || button.dataset.kcPathOpen
-      || button.dataset.kcOpenProduct
-      || "",
-    ).trim();
+    const product = String(button.dataset.kcPathOpen || "").trim();
     if (!KNOWN.has(product)) return;
 
     event.preventDefault();

--- a/academy/academy-recommended-buttons-fix.js
+++ b/academy/academy-recommended-buttons-fix.js
@@ -4,12 +4,11 @@
   if (window.__KINECHECK_RECOMMENDED_BUTTONS_FIX__) return;
   window.__KINECHECK_RECOMMENDED_BUTTONS_FIX__ = true;
 
-  const SELECTOR = [
-    "#kc-stage-recommendations [data-kc-path-open]",
-    "[data-kc-open-product]",
-    "#course-grid [data-course]",
-  ].join(",");
-  const OPENER_SRC = "./academy-open-v6.js?v=20260809-native-owned1";
+  // Solo las recomendaciones especiales usan el router alternativo.
+  // Inicio, Mis productos y Continuar deben llegar a los listeners nativos
+  // de Academy para reutilizar openCourse(), validación de licencia y SSO.
+  const SELECTOR = "#kc-stage-recommendations [data-kc-path-open]";
+  const OPENER_SRC = "./academy-open-v6.js?v=20260809-native-buttons2";
   let openerPromise = null;
 
   function toast(text) {
@@ -63,21 +62,11 @@
     return openerPromise;
   }
 
-  function productFor(button) {
-    return String(
-      button.dataset.kcPathOpen
-      || button.dataset.kcOpenProduct
-      || button.dataset.course
-      || "",
-    ).trim();
-  }
-
   document.addEventListener("click", async (event) => {
-    if (window.__KINECHECK_NATIVE_OWNED_PROXY__) return;
     const button = event.target.closest(SELECTOR);
     if (!button || button.disabled || button.getAttribute("aria-disabled") === "true") return;
 
-    const product = productFor(button);
+    const product = String(button.dataset.kcPathOpen || "").trim();
     if (!product) return;
 
     event.preventDefault();

--- a/tests/owned-buttons.spec.mjs
+++ b/tests/owned-buttons.spec.mjs
@@ -7,155 +7,120 @@ const FIX_SCRIPT = path.join(ROOT, "academy", "academy-recommended-buttons-fix.j
 const OPEN_SCRIPT = path.join(ROOT, "academy", "academy-open-v6.js");
 const MI_SCRIPT = path.join(ROOT, "academy", "mi-kinecheck-v1.js");
 
-const applications = ["kinecheck-estudiante", "kinecheck-recupera"];
-const courses = [
-  "kinecheck-clinico-curso",
-  "comunicacion-clinica",
-  "mas-alla-del-dolor",
-  "evidencia-aplicada",
-  "traumatologia-ortopedia-clinica",
-];
-
 test.use({ viewport: { width: 1440, height: 900 } });
 
-async function installHarness(page) {
-  await page.setContent(`
-    <!doctype html>
-    <html><head></head><body>
-      <div id="kc-toast" hidden></div>
-      <section id="home-app-grid"></section>
-      <section id="home-course-grid"></section>
-      <section id="guided-route"></section>
-      <section id="course-grid"></section>
-    </body></html>
-  `);
-
-  await page.evaluate(() => {
-    window.__openedProducts = [];
-    window.__navigationResets = 0;
-    window.KINECHECK_RESET_PRODUCT_NAVIGATION = () => {
-      window.__navigationResets += 1;
-    };
-    window.KINECHECK_OPEN_PRODUCT = async (product, button) => {
-      window.__openedProducts.push({ product, text: button.textContent.trim() });
-    };
-  });
-
-  await page.addScriptTag({ path: FIX_SCRIPT });
-}
-
-test("los botones de aplicaciones en Mis productos abren la aplicación exacta", async ({ page }) => {
-  await installHarness(page);
-
-  await page.evaluate((slugs) => {
-    document.querySelector("#home-app-grid").innerHTML = slugs.map((slug) => `
-      <article><button type="button" data-kc-open-product="${slug}">Abrir</button></article>
-    `).join("");
-  }, applications);
-
-  for (const product of applications) {
-    await page.locator(`[data-kc-open-product="${product}"]`).click();
-  }
-
-  await expect.poll(async () => page.evaluate(() => window.__openedProducts)).toEqual(
-    applications.map((product) => ({ product, text: "Abrir" })),
-  );
-});
-
-test("los botones de cursos en Inicio y Mis cursos abren el curso exacto", async ({ page }) => {
-  await installHarness(page);
-
-  await page.evaluate((slugs) => {
-    document.querySelector("#home-course-grid").innerHTML = slugs.slice(0, 2).map((slug) => `
-      <article><button type="button" data-kc-open-product="${slug}">Continuar</button></article>
-    `).join("");
-    document.querySelector("#course-grid").innerHTML = slugs.slice(2).map((slug) => `
-      <article><button type="button" data-course="${slug}">Continuar</button></article>
-    `).join("");
-  }, courses);
-
-  for (const product of courses.slice(0, 2)) {
-    await page.locator(`[data-kc-open-product="${product}"]`).click();
-  }
-  for (const product of courses.slice(2)) {
-    await page.locator(`#course-grid [data-course="${product}"]`).click();
-  }
-
-  await expect.poll(async () => page.evaluate(() => window.__openedProducts)).toEqual(
-    courses.map((product) => ({ product, text: "Continuar" })),
-  );
-});
-
-test("los botones Abrir de la ruta guiada reutilizan el flujo nativo de Mis productos", async ({ page }) => {
-  const guidedProducts = ["kinecheck-estudiante", "kinecheck-recupera", "comunicacion-clinica"];
-
+async function installNativeHarness(page) {
   await page.setContent(`
     <!doctype html>
     <html><head></head><body data-kc-experience="professional">
       <div id="kc-toast" hidden></div>
       <section id="dashboard-view"></section>
       <section id="inicio"></section>
+      <section id="home-app-grid"></section>
+      <section id="home-course-grid"></section>
       <section id="guided-route"></section>
       <section id="course-grid"></section>
+      <button id="continue-button" type="button">Continuar</button>
     </body></html>
   `);
 
-  await page.evaluate((slugs) => {
+  await page.evaluate(() => {
+    window.__nativeHome = [];
+    window.__nativeLibrary = [];
     window.KINECHECK_ACADEMY_CONFIG = { ownerEmails: [] };
-    window.__nativeOpenedProducts = [];
+
+    document.addEventListener("click", (event) => {
+      const button = event.target.closest("[data-kc-open-product]");
+      if (button) window.__nativeHome.push(button.dataset.kcOpenProduct);
+    });
+
+    document.querySelector("#course-grid").addEventListener("click", (event) => {
+      const button = event.target.closest("[data-course]");
+      if (button && !button.disabled) window.__nativeLibrary.push(button.dataset.course);
+    });
+  });
+
+  await page.addScriptTag({ path: OPEN_SCRIPT });
+  await page.addScriptTag({ path: FIX_SCRIPT });
+}
+
+test("Inicio deja pasar data-kc-open-product al flujo nativo", async ({ page }) => {
+  await installNativeHarness(page);
+
+  await page.evaluate(() => {
+    document.querySelector("#home-app-grid").innerHTML = `
+      <article><button type="button" data-kc-open-product="kinecheck-estudiante">Abrir</button></article>
+    `;
+  });
+
+  await page.locator('[data-kc-open-product="kinecheck-estudiante"]').click();
+  await expect.poll(async () => page.evaluate(() => window.__nativeHome)).toEqual(["kinecheck-estudiante"]);
+});
+
+test("Mis productos deja pasar data-course al openCourse nativo", async ({ page }) => {
+  await installNativeHarness(page);
+
+  await page.evaluate(() => {
+    document.querySelector("#course-grid").innerHTML = `
+      <article><button type="button" data-course="kinecheck-estudiante">Abrir desde biblioteca</button></article>
+    `;
+  });
+
+  await page.locator('#course-grid [data-course="kinecheck-estudiante"]').click();
+  await expect.poll(async () => page.evaluate(() => window.__nativeLibrary)).toEqual(["kinecheck-estudiante"]);
+});
+
+test("los botones Abrir de la ruta guiada reutilizan el flujo nativo de Mis productos", async ({ page }) => {
+  const guidedProducts = ["kinecheck-estudiante", "kinecheck-recupera", "comunicacion-clinica"];
+  await installNativeHarness(page);
+
+  await page.evaluate((slugs) => {
     document.querySelector("#guided-route").innerHTML = slugs.map((slug) => `
       <article><button type="button" data-kc-open-owned="${slug}">Abrir</button></article>
     `).join("");
     document.querySelector("#course-grid").innerHTML = slugs.map((slug) => `
       <article><button type="button" data-course="${slug}">Abrir desde biblioteca</button></article>
     `).join("");
-    document.querySelector("#course-grid").addEventListener("click", (event) => {
-      const button = event.target.closest("[data-course]");
-      if (button && !button.disabled) window.__nativeOpenedProducts.push(button.dataset.course);
-    });
   }, guidedProducts);
 
-  await page.addScriptTag({ path: OPEN_SCRIPT });
-  await page.addScriptTag({ path: FIX_SCRIPT });
   await page.addScriptTag({ path: MI_SCRIPT });
 
   for (const product of guidedProducts) {
     await page.locator(`#guided-route [data-kc-open-owned="${product}"]`).click();
   }
 
-  await expect.poll(async () => page.evaluate(() => window.__nativeOpenedProducts)).toEqual(guidedProducts);
+  await expect.poll(async () => page.evaluate(() => window.__nativeLibrary)).toEqual(guidedProducts);
 });
 
-test("el proxy nativo hace bypass de los routers auxiliares", async ({ page }) => {
+test("las recomendaciones especiales conservan el router alternativo", async ({ page }) => {
   await page.setContent(`
     <!doctype html>
     <html><head></head><body>
       <div id="kc-toast" hidden></div>
-      <section id="course-grid"><button type="button" data-course="comunicacion-clinica">Abrir</button></section>
+      <section id="kc-stage-recommendations">
+        <button type="button" data-kc-path-open="comunicacion-clinica">Abrir recomendación</button>
+      </section>
     </body></html>
   `);
 
   await page.evaluate(() => {
-    window.__nativeClicks = 0;
-    document.querySelector("#course-grid").addEventListener("click", () => { window.__nativeClicks += 1; });
+    window.__recommended = [];
+    window.KINECHECK_OPEN_PRODUCT = async (product) => { window.__recommended.push(product); };
+    window.KINECHECK_RESET_PRODUCT_NAVIGATION = () => {};
   });
-  await page.addScriptTag({ path: OPEN_SCRIPT });
   await page.addScriptTag({ path: FIX_SCRIPT });
 
-  await page.evaluate(() => {
-    window.__KINECHECK_NATIVE_OWNED_PROXY__ = true;
-    try {
-      document.querySelector('#course-grid [data-course="comunicacion-clinica"]').click();
-    } finally {
-      window.__KINECHECK_NATIVE_OWNED_PROXY__ = false;
-    }
-  });
-
-  await expect.poll(async () => page.evaluate(() => window.__nativeClicks)).toBe(1);
+  await page.locator('[data-kc-path-open="comunicacion-clinica"]').click();
+  await expect.poll(async () => page.evaluate(() => window.__recommended)).toEqual(["comunicacion-clinica"]);
 });
 
 test("al volver a Academy se libera cualquier estado de navegación", async ({ page }) => {
-  await installHarness(page);
+  await page.setContent('<!doctype html><html><body><div id="kc-toast" hidden></div></body></html>');
+  await page.evaluate(() => {
+    window.__navigationResets = 0;
+    window.KINECHECK_RESET_PRODUCT_NAVIGATION = () => { window.__navigationResets += 1; };
+  });
+  await page.addScriptTag({ path: FIX_SCRIPT });
   await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true })));
   await expect.poll(async () => page.evaluate(() => window.__navigationResets)).toBeGreaterThan(0);
 });


### PR DESCRIPTION
Corrige la discrepancia entre los botones de Inicio y el flujo de Mis productos.

Cambios:
- `academy-open-v6.js` deja de interceptar `data-course`, `data-kc-open-product` y `#continue-button`; queda reservado a `data-kc-path-open`.
- `academy-recommended-buttons-fix.js` deja de capturar botones nativos de Inicio/Mis productos y conserva solo recomendaciones especiales.
- `tests/owned-buttons.spec.mjs` verifica que Inicio y Mis productos llegan a los listeners nativos, que la ruta guiada reutiliza el flujo nativo y que las recomendaciones especiales conservan su router.

Objetivo: que Inicio y Mis productos terminen en el mismo `openCourse()` de Academy, con validación de licencia y SSO canónico.

No modifica Auth, Supabase, licencias, compras, webhooks, usuarios ni secretos.