### PR TITLE
Route Academy owned buttons through window native bridge

### DIFF
--- a/academy/academy-brand-identity.js
+++ b/academy/academy-brand-identity.js
@@ -86,6 +86,7 @@
   loadScript("../assets/observability.js", "data-kc-observability", "20260807-1");
   loadScript("./security-hardening-v1.js", "data-kc-security-hardening", "20260807-1");
   loadScript("../metrics-v1.js", "data-kc-launch-metrics", "20260806-launch-metrics1");
+  loadScript("./academy-owned-native-bridge-v1.js", "data-kc-owned-native-bridge", "20260809-windowbridge1");
   loadScript("./mi-kinecheck-v1.js", "data-mi-kinecheck", "20260809-native-owned1");
   loadScript("./mi-kinecheck-card-copy-v1.js", "data-mi-kinecheck-card-copy", "20260806-unified1");
   loadScript("./mi-kinecheck-simplify-v2.js", "data-mi-kinecheck-simplify-v2", "20260806-simplified3");

--- a/academy/academy-owned-native-bridge-v1.js
+++ b/academy/academy-owned-native-bridge-v1.js
@@ -1,0 +1,31 @@
+(() => {
+  "use strict";
+
+  if (window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__) return;
+  window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__ = true;
+
+  const SOURCE_SELECTOR = "[data-kc-open-product], [data-kc-open-owned]";
+
+  function nativeButton(slug) {
+    const safe = String(slug || "").trim();
+    if (!safe) return null;
+    return [...document.querySelectorAll("#course-grid [data-course]")]
+      .find((button) => !button.disabled && button.dataset.course === safe) || null;
+  }
+
+  window.addEventListener("click", (event) => {
+    const source = event.target instanceof Element ? event.target.closest(SOURCE_SELECTOR) : null;
+    if (!source || source.disabled || source.getAttribute("aria-disabled") === "true") return;
+
+    const slug = String(source.dataset.kcOpenProduct || source.dataset.kcOpenOwned || "").trim();
+    const target = nativeButton(slug);
+    if (!target) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+
+    // El botón de #course-grid es la entrada canónica a openCourse() en academy-v39.js.
+    target.click();
+  }, true);
+})();

--- a/tests/owned-buttons.spec.mjs
+++ b/tests/owned-buttons.spec.mjs
@@ -6,6 +6,7 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const FIX_SCRIPT = path.join(ROOT, "academy", "academy-recommended-buttons-fix.js");
 const OPEN_SCRIPT = path.join(ROOT, "academy", "academy-open-v6.js");
 const MI_SCRIPT = path.join(ROOT, "academy", "mi-kinecheck-v1.js");
+const BRIDGE_SCRIPT = path.join(ROOT, "academy", "academy-owned-native-bridge-v1.js");
 
 test.use({ viewport: { width: 1440, height: 900 } });
 
@@ -68,6 +69,50 @@ test("Mis productos deja pasar data-course al openCourse nativo", async ({ page 
 
   await page.locator('#course-grid [data-course="kinecheck-estudiante"]').click();
   await expect.poll(async () => page.evaluate(() => window.__nativeLibrary)).toEqual(["kinecheck-estudiante"]);
+});
+
+test("el bridge de window gana a interceptores de document y termina en el botón nativo", async ({ page }) => {
+  await page.setContent(`
+    <!doctype html>
+    <html><head></head><body>
+      <section id="inicio">
+        <button type="button" data-kc-open-product="kinecheck-estudiante">Abrir Estudiante</button>
+        <button type="button" data-kc-open-owned="kinecheck-recupera">Abrir Recupera</button>
+      </section>
+      <section id="course-grid">
+        <button type="button" data-course="kinecheck-estudiante">Nativo Estudiante</button>
+        <button type="button" data-course="kinecheck-recupera">Nativo Recupera</button>
+      </section>
+    </body></html>
+  `);
+
+  await page.evaluate(() => {
+    window.__nativeLibrary = [];
+    window.__blockedAtDocument = 0;
+
+    document.addEventListener("click", (event) => {
+      if (!event.target.closest("[data-kc-open-product], [data-kc-open-owned]")) return;
+      window.__blockedAtDocument += 1;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }, true);
+
+    document.querySelector("#course-grid").addEventListener("click", (event) => {
+      const button = event.target.closest("[data-course]");
+      if (button && !button.disabled) window.__nativeLibrary.push(button.dataset.course);
+    });
+  });
+
+  await page.addScriptTag({ path: BRIDGE_SCRIPT });
+
+  await page.locator('[data-kc-open-product="kinecheck-estudiante"]').click();
+  await page.locator('[data-kc-open-owned="kinecheck-recupera"]').click();
+
+  await expect.poll(async () => page.evaluate(() => window.__nativeLibrary)).toEqual([
+    "kinecheck-estudiante",
+    "kinecheck-recupera",
+  ]);
+  await expect.poll(async () => page.evaluate(() => window.__blockedAtDocument)).toBe(0);
 });
 
 test("los botones Abrir de la ruta guiada reutilizan el flujo nativo de Mis productos", async ({ page }) => {


### PR DESCRIPTION
Corrige el fallo persistente de los botones de Inicio/Mi ruta sin duplicar la lógica de licencias.

Cambios:
- nuevo `academy-owned-native-bridge-v1.js`, instalado en `window` capture para interceptar `data-kc-open-product` y `data-kc-open-owned` antes que listeners de `document`;
- cada clic se redirige al botón real `#course-grid [data-course]`, que sigue entrando al `openCourse()` canónico de `academy-v39.js`;
- `academy-brand-identity.js` carga el bridge antes de los helpers de UI;
- regresión Playwright que demuestra que el bridge gana a un interceptor de `document` y termina en el botón nativo.

No modifica Auth, Supabase, course_access, licencias, compras, webhooks, SSO backend, usuarios ni secretos.