### PR TITLE
Support fresh private sessions for external courses

### DIFF
--- a/academy/academy-bootstrap-v28.js
+++ b/academy/academy-bootstrap-v28.js
@@ -306,7 +306,7 @@ window.KINECHECK_ACADEMY_CONFIG = Object.freeze({
 (() => {
   if (document.querySelector('script[data-kc-brand-identity]')) return;
   const script = document.createElement("script");
-  script.src = "./academy-brand-identity.js?v=20260809-native-owned1";
+  script.src = "./academy-brand-identity.js?v=20260809-private1";
   script.async = false;
   script.dataset.kcBrandIdentity = "true";
   document.head.appendChild(script);

--- a/academy/academy-brand-identity.js
+++ b/academy/academy-brand-identity.js
@@ -86,13 +86,13 @@
   loadScript("../assets/observability.js", "data-kc-observability", "20260807-1");
   loadScript("./security-hardening-v1.js", "data-kc-security-hardening", "20260807-1");
   loadScript("../metrics-v1.js", "data-kc-launch-metrics", "20260806-launch-metrics1");
-  loadScript("./academy-owned-native-bridge-v1.js", "data-kc-owned-native-bridge", "20260809-windowbridge1");
+  loadScript("./academy-owned-native-bridge-v1.js", "data-kc-owned-native-bridge", "20260809-private1");
   loadScript("./mi-kinecheck-v1.js", "data-mi-kinecheck", "20260809-native-owned1");
   loadScript("./mi-kinecheck-card-copy-v1.js", "data-mi-kinecheck-card-copy", "20260806-unified1");
   loadScript("./mi-kinecheck-simplify-v2.js", "data-mi-kinecheck-simplify-v2", "20260806-simplified3");
 
-  loadScript("./academy-recommended-buttons-fix.js", "data-kc-recommended-buttons-fix", "20260809-native-owned1");
-  loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260809-native-owned1");
+  loadScript("./academy-recommended-buttons-fix.js", "data-kc-recommended-buttons-fix", "20260809-private1");
+  loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260809-private1");
   loadScript("./academy-clinico-course-v1.js", "data-kc-clinico-course", "20260806-final5");
 
   if (document.readyState === "loading") {

--- a/academy/academy-open-v6.js
+++ b/academy/academy-open-v6.js
@@ -6,9 +6,7 @@
 
   const SESSION_KEY = "kinecheck_secure_session_v1";
   const HANDOFF_TYPE = "kinecheck-sso-v3-access-only";
-  const READY_TYPE = "kinecheck-sso-ready";
-  const ACCEPTED_TYPE = "kinecheck-sso-accepted";
-  const RELEASE = "20260806-final5";
+  const RELEASE = "20260809-private1";
 
   const SAME_ORIGIN = Object.freeze({
     "kinecheck-clinico": `../kinecheck-clinico-guia/?product=kinecheck-clinico&v=${RELEASE}`,
@@ -71,6 +69,23 @@
       product,
       session: accessOnly(session),
     };
+  }
+
+  function encodeBase64Url(value) {
+    const bytes = new TextEncoder().encode(value);
+    let binary = "";
+    bytes.forEach((byte) => { binary += String.fromCharCode(byte); });
+    return btoa(binary)
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/g, "");
+  }
+
+  function externalHandoffUrl(targetUrl, session, product) {
+    const url = new URL(targetUrl);
+    const encoded = encodeBase64Url(JSON.stringify(payload(session, product)));
+    url.hash = new URLSearchParams({ kc_handoff: encoded }).toString();
+    return url.toString();
   }
 
   function toast(text) {
@@ -137,59 +152,21 @@
 
   async function openExternal(product, button) {
     const targetUrl = EXTERNAL[product];
-    const targetOrigin = new URL(targetUrl).origin;
-    const popup = window.open("about:blank", `kinecheck-${product}`);
-    if (!popup) {
-      toast("El navegador bloqueó la apertura del curso. Habilita ventanas emergentes para kinecheck.cl y vuelve a intentarlo.");
-      return;
-    }
-
     setBusy(button, true);
     const session = await usableSession();
     if (!session) {
-      popup.close();
       setBusy(button, false);
       toast("Tu sesión terminó. Ingresa nuevamente a KineCheck una sola vez.");
       return;
     }
 
-    const transfer = payload(session, product);
-    let accepted = false;
-    let intervalId = 0;
-    let timeoutId = 0;
-
-    const cleanup = () => {
-      window.removeEventListener("message", onMessage);
-      clearInterval(intervalId);
-      clearTimeout(timeoutId);
+    try {
+      window.name = "";
+      location.assign(externalHandoffUrl(targetUrl, session, product));
+    } catch {
       setBusy(button, false);
-    };
-
-    const send = () => {
-      if (accepted || popup.closed) return;
-      try { popup.postMessage(transfer, targetOrigin); } catch { /* reintento automático */ }
-    };
-
-    const onMessage = (event) => {
-      if (event.source !== popup || event.origin !== targetOrigin || event.data?.product !== product) return;
-      if (event.data?.type === READY_TYPE) {
-        send();
-        return;
-      }
-      if (event.data?.type === ACCEPTED_TYPE) {
-        accepted = true;
-        cleanup();
-      }
-    };
-
-    window.addEventListener("message", onMessage);
-    try { popup.name = JSON.stringify(transfer); } catch { /* postMessage es la vía principal */ }
-    popup.location.replace(targetUrl);
-    intervalId = window.setInterval(send, 500);
-    timeoutId = window.setTimeout(() => {
-      if (!accepted) toast("El curso tardó en confirmar el acceso. La pestaña permanece abierta para reintentar automáticamente.");
-      cleanup();
-    }, 15000);
+      toast("No fue posible transferir el acceso al curso. Vuelve a intentarlo.");
+    }
   }
 
   async function openApplication(product, button) {
@@ -216,9 +193,7 @@
 
   async function openProduct(product, button = null) {
     if (!KNOWN.has(product)) return;
-    if (navigating) {
-      resetNavigationState();
-    }
+    if (navigating) resetNavigationState();
     if (SAME_ORIGIN[product]) return openSameOrigin(product, button);
     if (EXTERNAL[product]) return openExternal(product, button);
     if (APPLICATIONS.has(product)) return openApplication(product, button);
@@ -227,9 +202,6 @@
   window.KINECHECK_OPEN_PRODUCT = openProduct;
   window.KINECHECK_RESET_PRODUCT_NAVIGATION = resetNavigationState;
 
-  // Este router queda reservado a recomendaciones especiales. Los botones
-  // nativos de Inicio/Mis productos/Continuar deben llegar a Academy v39,
-  // que valida licencia y ejecuta el SSO canónico mediante openCourse().
   document.addEventListener("click", (event) => {
     const button = event.target.closest("[data-kc-path-open]");
     if (!button || button.disabled || button.getAttribute("aria-disabled") === "true") return;

--- a/academy/academy-owned-native-bridge-v1.js
+++ b/academy/academy-owned-native-bridge-v1.js
@@ -4,7 +4,14 @@
   if (window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__) return;
   window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__ = true;
 
-  const SOURCE_SELECTOR = "[data-kc-open-product], [data-kc-open-owned]";
+  const SOURCE_SELECTOR = [
+    "[data-kc-open-product]",
+    "[data-kc-open-owned]",
+    "[data-kc-path-open]",
+    "#course-grid [data-course]",
+    "#continue-button[data-course]",
+  ].join(", ");
+  const EXTERNAL = new Set(["mas-alla-del-dolor", "evidencia-aplicada"]);
 
   function nativeButton(slug) {
     const safe = String(slug || "").trim();
@@ -13,11 +20,37 @@
       .find((button) => !button.disabled && button.dataset.course === safe) || null;
   }
 
+  function sourceSlug(source) {
+    return String(
+      source.dataset.kcOpenProduct
+      || source.dataset.kcOpenOwned
+      || source.dataset.kcPathOpen
+      || source.dataset.course
+      || "",
+    ).trim();
+  }
+
+  function isNativeSource(source) {
+    return source.matches("#course-grid [data-course], #continue-button[data-course]");
+  }
+
   window.addEventListener("click", (event) => {
     const source = event.target instanceof Element ? event.target.closest(SOURCE_SELECTOR) : null;
     if (!source || source.disabled || source.getAttribute("aria-disabled") === "true") return;
 
-    const slug = String(source.dataset.kcOpenProduct || source.dataset.kcOpenOwned || "").trim();
+    const slug = sourceSlug(source);
+    if (!slug) return;
+
+    if (EXTERNAL.has(slug) && typeof window.KINECHECK_OPEN_PRODUCT === "function") {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      window.KINECHECK_OPEN_PRODUCT(slug, source);
+      return;
+    }
+
+    if (isNativeSource(source)) return;
+
     const target = nativeButton(slug);
     if (!target) return;
 
@@ -25,7 +58,7 @@
     event.stopPropagation();
     event.stopImmediatePropagation();
 
-    // El botón de #course-grid es la entrada canónica a openCourse() en academy-v39.js.
+    // El botón de #course-grid es la entrada canónica a openCourse() en Academy.
     target.click();
   }, true);
 })();

--- a/academy/academy-recommended-buttons-fix.js
+++ b/academy/academy-recommended-buttons-fix.js
@@ -8,7 +8,7 @@
   // Inicio, Mis productos y Continuar deben llegar a los listeners nativos
   // de Academy para reutilizar openCourse(), validación de licencia y SSO.
   const SELECTOR = "#kc-stage-recommendations [data-kc-path-open]";
-  const OPENER_SRC = "./academy-open-v6.js?v=20260809-native-buttons2";
+  const OPENER_SRC = "./academy-open-v6.js?v=20260809-private1";
   let openerPromise = null;
 
   function toast(text) {

--- a/academy/index.html
+++ b/academy/index.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="./academy-v40.css?v=41">
   <link rel="stylesheet" href="./academy-evidence-alerts.css?v=20260731-2" data-academy-evidence="styles">
   <link rel="stylesheet" href="./academy-kinecheck-v4.css?v=20260731-1">
-  <script src="./academy-bootstrap-v28.js?v=20260803-accessfix2" defer></script>
+  <script src="./academy-bootstrap-v28.js?v=20260809-private1" defer></script>
   <script src="../watermark.js?v=20260730b" defer></script>
   <script src="./academy-v39.js?v=20260803-sessionfix2" defer></script>
   <script src="./academy-evidence-alerts.js?v=20260803-stable2" data-academy-evidence="script" defer></script>

--- a/tests/owned-buttons.spec.mjs
+++ b/tests/owned-buttons.spec.mjs
@@ -45,6 +45,10 @@ async function installNativeHarness(page) {
   await page.addScriptTag({ path: FIX_SCRIPT });
 }
 
+function decodeBase64UrlJson(value) {
+  return JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+}
+
 test("Inicio deja pasar data-kc-open-product al flujo nativo", async ({ page }) => {
   await installNativeHarness(page);
 
@@ -114,6 +118,100 @@ test("el bridge de window gana a interceptores de document y termina en el botó
   ]);
   await expect.poll(async () => page.evaluate(() => window.__blockedAtDocument)).toBe(0);
 });
+
+test("los cursos externos evitan listeners de document y usan el opener privado", async ({ page }) => {
+  await page.setContent(`
+    <!doctype html>
+    <html><body>
+      <section id="inicio">
+        <button type="button" data-kc-open-product="mas-alla-del-dolor">Más allá</button>
+      </section>
+      <section id="kc-stage-recommendations">
+        <button type="button" data-kc-path-open="evidencia-aplicada">Evidencia</button>
+      </section>
+      <section id="course-grid">
+        <button type="button" data-course="mas-alla-del-dolor">Biblioteca Más allá</button>
+        <button type="button" data-course="evidencia-aplicada">Biblioteca Evidencia</button>
+      </section>
+    </body></html>
+  `);
+
+  await page.evaluate(() => {
+    window.__external = [];
+    window.__documentIntercepts = 0;
+    window.KINECHECK_OPEN_PRODUCT = (slug) => { window.__external.push(slug); };
+
+    document.addEventListener("click", (event) => {
+      if (!event.target.closest("[data-kc-open-product], [data-kc-path-open], [data-course]")) return;
+      window.__documentIntercepts += 1;
+      event.stopImmediatePropagation();
+    }, true);
+  });
+
+  await page.addScriptTag({ path: BRIDGE_SCRIPT });
+
+  await page.locator('[data-kc-open-product="mas-alla-del-dolor"]').click();
+  await page.locator('[data-kc-path-open="evidencia-aplicada"]').click();
+  await page.locator('#course-grid [data-course="mas-alla-del-dolor"]').click();
+
+  await expect.poll(async () => page.evaluate(() => window.__external)).toEqual([
+    "mas-alla-del-dolor",
+    "evidencia-aplicada",
+    "mas-alla-del-dolor",
+  ]);
+  await expect.poll(async () => page.evaluate(() => window.__documentIntercepts)).toBe(0);
+});
+
+for (const [product, pathname] of [
+  ["mas-alla-del-dolor", "/mas-alla-del-dolor/"],
+  ["evidencia-aplicada", "/kinecheck-evidencia-aplicada/"],
+]) {
+  test(`sesión fresca entrega ${product} por fragmento efímero sin datos extra`, async ({ page }) => {
+    const accessToken = "private-session-access-token-1234567890";
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+
+    await page.setContent(`
+      <!doctype html><html><body>
+        <div id="kc-toast" hidden></div>
+        <button type="button" data-kc-path-open="${product}">Abrir externo</button>
+      </body></html>
+    `);
+    await page.evaluate(({ accessToken: token, expiresAt: expiry }) => {
+      window.KINECHECK_ACADEMY_SESSION = {
+        get: () => ({
+          access_token: token,
+          expires_at: expiry,
+          refresh_token: "NO-DEBE-SALIR",
+          user: { email: "no-debe-salir@example.com" },
+        }),
+      };
+    }, { accessToken, expiresAt });
+
+    await page.route(`https://emmanuelkine.github.io${pathname}**`, async (route) => {
+      await route.fulfill({ status: 200, contentType: "text/html", body: "<!doctype html><title>Destino</title>" });
+    });
+    await page.addScriptTag({ path: OPEN_SCRIPT });
+
+    await Promise.all([
+      page.waitForURL((url) => url.hostname === "emmanuelkine.github.io" && url.pathname === pathname),
+      page.locator(`[data-kc-path-open="${product}"]`).click(),
+    ]);
+
+    const destination = new URL(page.url());
+    const encoded = new URLSearchParams(destination.hash.slice(1)).get("kc_handoff");
+    expect(encoded).toBeTruthy();
+
+    const handoff = decodeBase64UrlJson(encoded);
+    expect(handoff.type).toBe("kinecheck-sso-v3-access-only");
+    expect(handoff.product).toBe(product);
+    expect(handoff.session.access_token).toBe(accessToken);
+    expect(handoff.session.expires_at).toBe(expiresAt);
+    expect(handoff.session.refresh_token).toBeUndefined();
+    expect(handoff.session.user).toBeUndefined();
+    expect(JSON.stringify(handoff)).not.toContain("no-debe-salir@example.com");
+    expect(JSON.stringify(handoff)).not.toContain("NO-DEBE-SALIR");
+  });
+}
 
 test("los botones Abrir de la ruta guiada reutilizan el flujo nativo de Mis productos", async ({ page }) => {
   const guidedProducts = ["kinecheck-estudiante", "kinecheck-recupera", "comunicacion-clinica"];


### PR DESCRIPTION
Corrige el fallo reproducible en navegación privada/incógnita al abrir cursos externos desde Academy.

Cambios:
- `academy-open-v6.js` deja de depender de popup + `window.opener` para cursos externos y usa un handoff efímero en el fragmento de la navegación;
- el payload contiene solo `access_token`, expiración y tipo de token; no transfiere correo ni `refresh_token`;
- `academy-owned-native-bridge-v1.js` enruta Más allá del dolor y Evidencia Aplicada por este handoff desde Inicio, recomendaciones, Mis productos y Continuar;
- cache bust coordinado;
- Playwright prueba una sesión fresca sin historial, el routing de botones externos y que el payload no contiene correo ni `refresh_token`.

No modifica Auth, Supabase, course_access, compras, webhooks, SSO backend, usuarios ni secretos.