### PR TITLE
Fix all Academy buttons with direct navigation

### DIFF
--- a/.github/workflows/validate-recommended-buttons.yml
+++ b/.github/workflows/validate-recommended-buttons.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - 'academy/academy-open-v6.js'
+      - 'academy/academy-owned-native-bridge-v1.js'
       - 'academy/academy-recommended-buttons-fix.js'
       - 'academy/academy-brand-identity.js'
       - 'academy/academy-learning-path-v4.js'
@@ -17,6 +18,7 @@ on:
     branches: [main]
     paths:
       - 'academy/academy-open-v6.js'
+      - 'academy/academy-owned-native-bridge-v1.js'
       - 'academy/academy-recommended-buttons-fix.js'
       - 'academy/academy-brand-identity.js'
       - 'academy/academy-learning-path-v4.js'

--- a/academy/academy-brand-identity.js
+++ b/academy/academy-brand-identity.js
@@ -47,7 +47,7 @@
     const onboardingAction = document.querySelector("#onboarding-action");
     if (onboardingAction) {
       onboardingAction.setAttribute("data-kc-view-link", "biblioteca");
-      onboardingAction.setAttribute("aria-label", "Ver mi biblioteca");
+      onboardingAction.setAttribute("aria-label", "Ver mis productos");
     }
 
     const catalogButton = document.querySelector(".kc-catalog-button");
@@ -86,13 +86,14 @@
   loadScript("../assets/observability.js", "data-kc-observability", "20260807-1");
   loadScript("./security-hardening-v1.js", "data-kc-security-hardening", "20260807-1");
   loadScript("../metrics-v1.js", "data-kc-launch-metrics", "20260806-launch-metrics1");
-  loadScript("./academy-owned-native-bridge-v1.js", "data-kc-owned-native-bridge", "20260809-private1");
+
+  // Orden deliberado: primero existe un único opener; luego el controlador de clicks.
+  loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260809-directnav1");
+  loadScript("./academy-owned-native-bridge-v1.js", "data-kc-owned-native-bridge", "20260809-directnav1");
+
   loadScript("./mi-kinecheck-v1.js", "data-mi-kinecheck", "20260809-native-owned1");
   loadScript("./mi-kinecheck-card-copy-v1.js", "data-mi-kinecheck-card-copy", "20260806-unified1");
   loadScript("./mi-kinecheck-simplify-v2.js", "data-mi-kinecheck-simplify-v2", "20260806-simplified3");
-
-  loadScript("./academy-recommended-buttons-fix.js", "data-kc-recommended-buttons-fix", "20260809-private1");
-  loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260809-private1");
   loadScript("./academy-clinico-course-v1.js", "data-kc-clinico-course", "20260806-final5");
 
   if (document.readyState === "loading") {

--- a/academy/academy-owned-native-bridge-v1.js
+++ b/academy/academy-owned-native-bridge-v1.js
@@ -4,61 +4,231 @@
   if (window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__) return;
   window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__ = true;
 
-  const SOURCE_SELECTOR = [
+  const PRODUCT_SELECTOR = [
     "[data-kc-open-product]",
     "[data-kc-open-owned]",
     "[data-kc-path-open]",
     "#course-grid [data-course]",
     "#continue-button[data-course]",
   ].join(", ");
-  const EXTERNAL = new Set(["mas-alla-del-dolor", "evidencia-aplicada"]);
 
-  function nativeButton(slug) {
-    const safe = String(slug || "").trim();
-    if (!safe) return null;
-    return [...document.querySelectorAll("#course-grid [data-course]")]
-      .find((button) => !button.disabled && button.dataset.course === safe) || null;
+  const STUDENT_ORDER = [
+    "kinecheck-estudiante",
+    "mas-alla-del-dolor",
+    "comunicacion-clinica",
+    "evidencia-aplicada",
+    "traumatologia-ortopedia-clinica",
+  ];
+
+  const VIEW_ALIASES = Object.freeze({
+    productos: "biblioteca",
+    recursos: "biblioteca",
+    "evidencia-semanal": "biblioteca",
+    "mis-cursos": "biblioteca",
+    cuenta: "perfil",
+    "mi-cuenta": "perfil",
+  });
+  const VIEWS = new Set(["inicio", "biblioteca", "herramientas", "perfil", "explorar"]);
+
+  function toast(text) {
+    const element = document.querySelector("#kc-toast");
+    if (!element) return;
+    element.textContent = text;
+    element.hidden = false;
+    window.clearTimeout(toast.timer);
+    toast.timer = window.setTimeout(() => { element.hidden = true; }, 4500);
   }
 
   function sourceSlug(source) {
     return String(
-      source.dataset.kcOpenProduct
-      || source.dataset.kcOpenOwned
-      || source.dataset.kcPathOpen
-      || source.dataset.course
+      source?.dataset?.kcOpenProduct
+      || source?.dataset?.kcOpenOwned
+      || source?.dataset?.kcPathOpen
+      || source?.dataset?.course
       || "",
     ).trim();
   }
 
-  function isNativeSource(source) {
-    return source.matches("#course-grid [data-course], #continue-button[data-course]");
+  function activeCourse(slug) {
+    return [...document.querySelectorAll("#course-grid [data-course]")]
+      .find((button) => !button.disabled && String(button.dataset.course || "").trim() === slug) || null;
   }
 
-  window.addEventListener("click", (event) => {
-    const source = event.target instanceof Element ? event.target.closest(SOURCE_SELECTOR) : null;
-    if (!source || source.disabled || source.getAttribute("aria-disabled") === "true") return;
+  function firstStudentCourse() {
+    return STUDENT_ORDER.find((slug) => activeCourse(slug)) || "";
+  }
 
-    const slug = sourceSlug(source);
+  function normalizeView(view) {
+    const raw = String(view || "").replace(/^#/, "").trim().toLowerCase();
+    const mapped = VIEW_ALIASES[raw] || raw;
+    return VIEWS.has(mapped) ? mapped : "inicio";
+  }
+
+  function activateView(view, scrollTarget = "") {
+    const next = normalizeView(view);
+    document.body.dataset.kcView = next;
+
+    document.querySelectorAll("[data-kc-view-link]").forEach((link) => {
+      link.classList.toggle("active", normalizeView(link.dataset.kcViewLink) === next);
+    });
+
+    const targetHash = `#${next}`;
+    if (location.hash !== targetHash) history.pushState(null, "", targetHash);
+
+    document.querySelector("#academy-sidebar")?.classList.remove("open");
+    const overlay = document.querySelector("#sidebar-overlay");
+    if (overlay) overlay.hidden = true;
+    document.querySelector("#mobile-menu")?.setAttribute("aria-expanded", "false");
+
+    window.requestAnimationFrame(() => {
+      if (scrollTarget) {
+        document.getElementById(scrollTarget)?.scrollIntoView({ behavior: "smooth", block: "start" });
+      } else {
+        window.scrollTo({ top: 0, behavior: "smooth" });
+      }
+    });
+  }
+
+  async function openSlug(slug, source) {
     if (!slug) return;
 
-    if (EXTERNAL.has(slug) && typeof window.KINECHECK_OPEN_PRODUCT === "function") {
-      event.preventDefault();
-      event.stopPropagation();
-      event.stopImmediatePropagation();
-      window.KINECHECK_OPEN_PRODUCT(slug, source);
-      return;
+    try {
+      if (typeof window.KINECHECK_ACADEMY_OPEN_COURSE === "function") {
+        await window.KINECHECK_ACADEMY_OPEN_COURSE(slug);
+        return;
+      }
+
+      if (typeof window.KINECHECK_OPEN_PRODUCT === "function") {
+        await window.KINECHECK_OPEN_PRODUCT(slug, source || null);
+        return;
+      }
+
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < 4000) {
+        await new Promise((resolve) => window.setTimeout(resolve, 40));
+        if (typeof window.KINECHECK_ACADEMY_OPEN_COURSE === "function") {
+          await window.KINECHECK_ACADEMY_OPEN_COURSE(slug);
+          return;
+        }
+        if (typeof window.KINECHECK_OPEN_PRODUCT === "function") {
+          await window.KINECHECK_OPEN_PRODUCT(slug, source || null);
+          return;
+        }
+      }
+
+      throw new Error("El controlador de acceso no terminó de cargar.");
+    } catch (error) {
+      source?.removeAttribute?.("aria-busy");
+      if (source?.style) source.style.pointerEvents = "";
+      toast(error instanceof Error ? error.message : "No fue posible abrir el producto.");
     }
+  }
 
-    if (isNativeSource(source)) return;
-
-    const target = nativeButton(slug);
-    if (!target) return;
-
+  function stop(event) {
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation();
+  }
 
-    // El botón de #course-grid es la entrada canónica a openCourse() en Academy.
-    target.click();
+  window.addEventListener("click", (event) => {
+    const target = event.target instanceof Element ? event.target : null;
+    if (!target) return;
+
+    const product = target.closest(PRODUCT_SELECTOR);
+    if (product && !product.disabled && product.getAttribute("aria-disabled") !== "true") {
+      const slug = sourceSlug(product);
+      if (!slug) return;
+      stop(event);
+      void openSlug(slug, product);
+      return;
+    }
+
+    const homeContinue = target.closest("#kc-home-continue");
+    if (homeContinue) {
+      stop(event);
+      const remembered = String(document.querySelector("#continue-button")?.dataset?.course || "").trim();
+      const role = String(document.body.dataset.kcExperience || "").trim();
+      const fallback = role === "patient"
+        ? (activeCourse("kinecheck-recupera") ? "kinecheck-recupera" : "")
+        : role === "student"
+          ? firstStudentCourse()
+          : "";
+      const slug = remembered || fallback;
+      if (slug) void openSlug(slug, homeContinue);
+      else activateView("biblioteca");
+      return;
+    }
+
+    const simplifiedView = target.closest("[data-mi-kc-view]");
+    if (simplifiedView) {
+      stop(event);
+      activateView(simplifiedView.dataset.miKcView);
+      return;
+    }
+
+    const viewLink = target.closest("[data-kc-view-link]");
+    if (viewLink) {
+      stop(event);
+      activateView(viewLink.dataset.kcViewLink, viewLink.dataset.kcScrollTarget || "");
+      return;
+    }
+
+    const scrollLink = target.closest("[data-kc-scroll-target]");
+    if (scrollLink) {
+      stop(event);
+      activateView("biblioteca", scrollLink.dataset.kcScrollTarget || "");
+      return;
+    }
+
+    const exploreProduct = target.closest("[data-kc-explore-product]");
+    if (exploreProduct) {
+      stop(event);
+      activateView("explorar");
+      return;
+    }
+
+    const mobileMenu = target.closest("#mobile-menu");
+    if (mobileMenu) {
+      stop(event);
+      const sidebar = document.querySelector("#academy-sidebar");
+      const overlay = document.querySelector("#sidebar-overlay");
+      const open = !sidebar?.classList.contains("open");
+      sidebar?.classList.toggle("open", open);
+      if (overlay) overlay.hidden = !open;
+      mobileMenu.setAttribute("aria-expanded", String(open));
+      return;
+    }
+
+    if (target.closest("#sidebar-overlay")) {
+      stop(event);
+      document.querySelector("#academy-sidebar")?.classList.remove("open");
+      const overlay = document.querySelector("#sidebar-overlay");
+      if (overlay) overlay.hidden = true;
+      document.querySelector("#mobile-menu")?.setAttribute("aria-expanded", "false");
+      return;
+    }
+
+    const supportOpen = target.closest("[data-support-open]");
+    if (supportOpen) {
+      stop(event);
+      const panel = document.querySelector("#support-panel");
+      const launcher = document.querySelector("#support-launcher");
+      if (panel) panel.hidden = false;
+      launcher?.setAttribute("aria-expanded", "true");
+      return;
+    }
+
+    const supportClose = target.closest("[data-support-close]");
+    if (supportClose) {
+      stop(event);
+      const panel = document.querySelector("#support-panel");
+      const launcher = document.querySelector("#support-launcher");
+      if (panel) panel.hidden = true;
+      launcher?.setAttribute("aria-expanded", "false");
+    }
   }, true);
+
+  window.addEventListener("pageshow", () => {
+    window.KINECHECK_RESET_PRODUCT_NAVIGATION?.();
+  });
 })();

--- a/tests/owned-buttons.spec.mjs
+++ b/tests/owned-buttons.spec.mjs
@@ -3,267 +3,150 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const FIX_SCRIPT = path.join(ROOT, "academy", "academy-recommended-buttons-fix.js");
-const OPEN_SCRIPT = path.join(ROOT, "academy", "academy-open-v6.js");
-const MI_SCRIPT = path.join(ROOT, "academy", "mi-kinecheck-v1.js");
 const BRIDGE_SCRIPT = path.join(ROOT, "academy", "academy-owned-native-bridge-v1.js");
 
-test.use({ viewport: { width: 1440, height: 900 } });
+test.use({ viewport: { width: 390, height: 844 } });
 
-async function installNativeHarness(page) {
+async function installHarness(page) {
   await page.setContent(`
     <!doctype html>
-    <html><head></head><body data-kc-experience="professional">
+    <html><head></head><body data-kc-view="inicio" data-kc-experience="professional">
       <div id="kc-toast" hidden></div>
-      <section id="dashboard-view"></section>
-      <section id="inicio"></section>
-      <section id="home-app-grid"></section>
-      <section id="home-course-grid"></section>
-      <section id="guided-route"></section>
-      <section id="course-grid"></section>
-      <button id="continue-button" type="button">Continuar</button>
-    </body></html>
-  `);
+      <button id="mobile-menu" type="button" aria-expanded="false">Menu</button>
+      <div id="sidebar-overlay" hidden></div>
+      <aside id="academy-sidebar"></aside>
+      <div id="support-panel" hidden></div>
+      <button id="support-launcher" data-support-open aria-expanded="false">Soporte</button>
 
-  await page.evaluate(() => {
-    window.__nativeHome = [];
-    window.__nativeLibrary = [];
-    window.KINECHECK_ACADEMY_CONFIG = { ownerEmails: [] };
+      <nav>
+        <a id="nav-inicio" href="#inicio" data-kc-view-link="inicio">Inicio</a>
+        <a id="nav-productos" href="#biblioteca" data-kc-view-link="biblioteca">Mis productos</a>
+        <a id="nav-recursos" href="#herramientas" data-kc-view-link="herramientas">Recursos</a>
+        <a id="nav-cuenta" href="#perfil" data-kc-view-link="perfil">Cuenta y ayuda</a>
+      </nav>
 
-    document.addEventListener("click", (event) => {
-      const button = event.target.closest("[data-kc-open-product]");
-      if (button) window.__nativeHome.push(button.dataset.kcOpenProduct);
-    });
+      <button id="onboarding-action" type="button" data-kc-view-link="biblioteca">Mis productos</button>
+      <button id="simple-resources" type="button" data-mi-kc-view="herramientas">Abrir recursos</button>
 
-    document.querySelector("#course-grid").addEventListener("click", (event) => {
-      const button = event.target.closest("[data-course]");
-      if (button && !button.disabled) window.__nativeLibrary.push(button.dataset.course);
-    });
-  });
-
-  await page.addScriptTag({ path: OPEN_SCRIPT });
-  await page.addScriptTag({ path: FIX_SCRIPT });
-}
-
-function decodeBase64UrlJson(value) {
-  return JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
-}
-
-test("Inicio deja pasar data-kc-open-product al flujo nativo", async ({ page }) => {
-  await installNativeHarness(page);
-
-  await page.evaluate(() => {
-    document.querySelector("#home-app-grid").innerHTML = `
-      <article><button type="button" data-kc-open-product="kinecheck-estudiante">Abrir</button></article>
-    `;
-  });
-
-  await page.locator('[data-kc-open-product="kinecheck-estudiante"]').click();
-  await expect.poll(async () => page.evaluate(() => window.__nativeHome)).toEqual(["kinecheck-estudiante"]);
-});
-
-test("Mis productos deja pasar data-course al openCourse nativo", async ({ page }) => {
-  await installNativeHarness(page);
-
-  await page.evaluate(() => {
-    document.querySelector("#course-grid").innerHTML = `
-      <article><button type="button" data-course="kinecheck-estudiante">Abrir desde biblioteca</button></article>
-    `;
-  });
-
-  await page.locator('#course-grid [data-course="kinecheck-estudiante"]').click();
-  await expect.poll(async () => page.evaluate(() => window.__nativeLibrary)).toEqual(["kinecheck-estudiante"]);
-});
-
-test("el bridge de window gana a interceptores de document y termina en el botón nativo", async ({ page }) => {
-  await page.setContent(`
-    <!doctype html>
-    <html><head></head><body>
-      <section id="inicio">
-        <button type="button" data-kc-open-product="kinecheck-estudiante">Abrir Estudiante</button>
-        <button type="button" data-kc-open-owned="kinecheck-recupera">Abrir Recupera</button>
-      </section>
       <section id="course-grid">
-        <button type="button" data-course="kinecheck-estudiante">Nativo Estudiante</button>
-        <button type="button" data-course="kinecheck-recupera">Nativo Recupera</button>
+        <button type="button" data-course="comunicacion-clinica">Comunicación</button>
+        <button type="button" data-course="kinecheck-clinico-curso">Clínico curso</button>
+        <button type="button" data-course="traumatologia-ortopedia-clinica">Trauma</button>
+        <button type="button" data-course="kinecheck-recupera">Recupera</button>
       </section>
+
+      <button id="home-clinico" type="button" data-kc-open-product="kinecheck-clinico">Clínico</button>
+      <button id="owned-student" type="button" data-kc-open-owned="kinecheck-estudiante">Estudiante</button>
+      <button id="recommended-pain" type="button" data-kc-path-open="mas-alla-del-dolor">Dolor</button>
+      <button id="home-recupera" type="button" data-kc-open-product="kinecheck-recupera">Recupera home</button>
+      <button id="continue-button" type="button" data-course="evidencia-aplicada">Continuar</button>
+      <button id="kc-home-continue" type="button">Continuar actividad</button>
     </body></html>
   `);
 
   await page.evaluate(() => {
-    window.__nativeLibrary = [];
-    window.__blockedAtDocument = 0;
-
-    document.addEventListener("click", (event) => {
-      if (!event.target.closest("[data-kc-open-product], [data-kc-open-owned]")) return;
-      window.__blockedAtDocument += 1;
-      event.preventDefault();
-      event.stopImmediatePropagation();
-    }, true);
-
-    document.querySelector("#course-grid").addEventListener("click", (event) => {
-      const button = event.target.closest("[data-course]");
-      if (button && !button.disabled) window.__nativeLibrary.push(button.dataset.course);
+    window.__opened = [];
+    window.__courseGridProxyClicks = 0;
+    window.KINECHECK_OPEN_PRODUCT = async (slug) => {
+      window.__opened.push(slug);
+    };
+    document.querySelector("#course-grid").addEventListener("click", () => {
+      window.__courseGridProxyClicks += 1;
     });
   });
 
   await page.addScriptTag({ path: BRIDGE_SCRIPT });
+}
 
-  await page.locator('[data-kc-open-product="kinecheck-estudiante"]').click();
-  await page.locator('[data-kc-open-owned="kinecheck-recupera"]').click();
+test("todos los puntos de entrada abren el producto directamente, sin click proxy", async ({ page }) => {
+  await installHarness(page);
 
-  await expect.poll(async () => page.evaluate(() => window.__nativeLibrary)).toEqual([
+  await page.locator("#home-clinico").click();
+  await page.locator("#owned-student").click();
+  await page.locator("#recommended-pain").click();
+  await page.locator('#course-grid [data-course="comunicacion-clinica"]').click();
+  await page.locator('#course-grid [data-course="kinecheck-clinico-curso"]').click();
+  await page.locator("#home-recupera").click();
+  await page.locator("#continue-button").click();
+
+  await expect.poll(async () => page.evaluate(() => window.__opened)).toEqual([
+    "kinecheck-clinico",
     "kinecheck-estudiante",
+    "mas-alla-del-dolor",
+    "comunicacion-clinica",
+    "kinecheck-clinico-curso",
     "kinecheck-recupera",
-  ]);
-  await expect.poll(async () => page.evaluate(() => window.__blockedAtDocument)).toBe(0);
-});
-
-test("los cursos externos evitan listeners de document y usan el opener privado", async ({ page }) => {
-  await page.setContent(`
-    <!doctype html>
-    <html><body>
-      <section id="inicio">
-        <button type="button" data-kc-open-product="mas-alla-del-dolor">Más allá</button>
-      </section>
-      <section id="kc-stage-recommendations">
-        <button type="button" data-kc-path-open="evidencia-aplicada">Evidencia</button>
-      </section>
-      <section id="course-grid">
-        <button type="button" data-course="mas-alla-del-dolor">Biblioteca Más allá</button>
-        <button type="button" data-course="evidencia-aplicada">Biblioteca Evidencia</button>
-      </section>
-    </body></html>
-  `);
-
-  await page.evaluate(() => {
-    window.__external = [];
-    window.__documentIntercepts = 0;
-    window.KINECHECK_OPEN_PRODUCT = (slug) => { window.__external.push(slug); };
-
-    document.addEventListener("click", (event) => {
-      if (!event.target.closest("[data-kc-open-product], [data-kc-path-open], [data-course]")) return;
-      window.__documentIntercepts += 1;
-      event.stopImmediatePropagation();
-    }, true);
-  });
-
-  await page.addScriptTag({ path: BRIDGE_SCRIPT });
-
-  await page.locator('[data-kc-open-product="mas-alla-del-dolor"]').click();
-  await page.locator('[data-kc-path-open="evidencia-aplicada"]').click();
-  await page.locator('#course-grid [data-course="mas-alla-del-dolor"]').click();
-
-  await expect.poll(async () => page.evaluate(() => window.__external)).toEqual([
-    "mas-alla-del-dolor",
     "evidencia-aplicada",
-    "mas-alla-del-dolor",
   ]);
-  await expect.poll(async () => page.evaluate(() => window.__documentIntercepts)).toBe(0);
+
+  await expect.poll(async () => page.evaluate(() => window.__courseGridProxyClicks)).toBe(0);
 });
 
-for (const [product, pathname] of [
-  ["mas-alla-del-dolor", "/mas-alla-del-dolor/"],
-  ["evidencia-aplicada", "/kinecheck-evidencia-aplicada/"],
-]) {
-  test(`sesión fresca entrega ${product} por fragmento efímero sin datos extra`, async ({ page }) => {
-    const accessToken = "private-session-access-token-1234567890";
-    const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+test("Continuar actividad usa el producto recordado sin depender de otro listener", async ({ page }) => {
+  await installHarness(page);
 
-    await page.setContent(`
-      <!doctype html><html><body>
-        <div id="kc-toast" hidden></div>
-        <button type="button" data-kc-path-open="${product}">Abrir externo</button>
-      </body></html>
-    `);
-    await page.evaluate(({ accessToken: token, expiresAt: expiry }) => {
-      window.KINECHECK_ACADEMY_SESSION = {
-        get: () => ({
-          access_token: token,
-          expires_at: expiry,
-          refresh_token: "NO-DEBE-SALIR",
-          user: { email: "no-debe-salir@example.com" },
-        }),
-      };
-    }, { accessToken, expiresAt });
-
-    await page.route(`https://emmanuelkine.github.io${pathname}**`, async (route) => {
-      await route.fulfill({ status: 200, contentType: "text/html", body: "<!doctype html><title>Destino</title>" });
-    });
-    await page.addScriptTag({ path: OPEN_SCRIPT });
-
-    await Promise.all([
-      page.waitForURL((url) => url.hostname === "emmanuelkine.github.io" && url.pathname === pathname),
-      page.locator(`[data-kc-path-open="${product}"]`).click(),
-    ]);
-
-    const destination = new URL(page.url());
-    const encoded = new URLSearchParams(destination.hash.slice(1)).get("kc_handoff");
-    expect(encoded).toBeTruthy();
-
-    const handoff = decodeBase64UrlJson(encoded);
-    expect(handoff.type).toBe("kinecheck-sso-v3-access-only");
-    expect(handoff.product).toBe(product);
-    expect(handoff.session.access_token).toBe(accessToken);
-    expect(handoff.session.expires_at).toBe(expiresAt);
-    expect(handoff.session.refresh_token).toBeUndefined();
-    expect(handoff.session.user).toBeUndefined();
-    expect(JSON.stringify(handoff)).not.toContain("no-debe-salir@example.com");
-    expect(JSON.stringify(handoff)).not.toContain("NO-DEBE-SALIR");
+  await page.evaluate(() => {
+    document.querySelector("#continue-button").dataset.course = "traumatologia-ortopedia-clinica";
   });
-}
+  await page.locator("#kc-home-continue").click();
 
-test("los botones Abrir de la ruta guiada reutilizan el flujo nativo de Mis productos", async ({ page }) => {
-  const guidedProducts = ["kinecheck-estudiante", "kinecheck-recupera", "comunicacion-clinica"];
-  await installNativeHarness(page);
-
-  await page.evaluate((slugs) => {
-    document.querySelector("#guided-route").innerHTML = slugs.map((slug) => `
-      <article><button type="button" data-kc-open-owned="${slug}">Abrir</button></article>
-    `).join("");
-    document.querySelector("#course-grid").innerHTML = slugs.map((slug) => `
-      <article><button type="button" data-course="${slug}">Abrir desde biblioteca</button></article>
-    `).join("");
-  }, guidedProducts);
-
-  await page.addScriptTag({ path: MI_SCRIPT });
-
-  for (const product of guidedProducts) {
-    await page.locator(`#guided-route [data-kc-open-owned="${product}"]`).click();
-  }
-
-  await expect.poll(async () => page.evaluate(() => window.__nativeLibrary)).toEqual(guidedProducts);
+  await expect.poll(async () => page.evaluate(() => window.__opened)).toEqual([
+    "traumatologia-ortopedia-clinica",
+  ]);
 });
 
-test("las recomendaciones especiales conservan el router alternativo", async ({ page }) => {
+test("Mis productos, Recursos, Cuenta y navegación móvil funcionan desde el controlador directo", async ({ page }) => {
+  await installHarness(page);
+
+  await page.locator("#onboarding-action").click();
+  await expect(page.locator("body")).toHaveAttribute("data-kc-view", "biblioteca");
+  await expect(page.locator("#nav-productos")).toHaveClass(/active/);
+  await expect.poll(async () => page.evaluate(() => location.hash)).toBe("#biblioteca");
+
+  await page.locator("#simple-resources").click();
+  await expect(page.locator("body")).toHaveAttribute("data-kc-view", "herramientas");
+  await expect(page.locator("#nav-recursos")).toHaveClass(/active/);
+
+  await page.locator("#nav-cuenta").click();
+  await expect(page.locator("body")).toHaveAttribute("data-kc-view", "perfil");
+  await expect(page.locator("#nav-cuenta")).toHaveClass(/active/);
+
+  await page.locator("#mobile-menu").click();
+  await expect(page.locator("#academy-sidebar")).toHaveClass(/open/);
+  await expect(page.locator("#mobile-menu")).toHaveAttribute("aria-expanded", "true");
+  await expect(page.locator("#sidebar-overlay")).not.toHaveAttribute("hidden", "");
+
+  await page.locator("#sidebar-overlay").click({ position: { x: 1, y: 1 } });
+  await expect(page.locator("#academy-sidebar")).not.toHaveClass(/open/);
+  await expect(page.locator("#mobile-menu")).toHaveAttribute("aria-expanded", "false");
+});
+
+test("Soporte responde aunque los listeners secundarios no carguen", async ({ page }) => {
+  await installHarness(page);
+
+  await page.locator("#support-launcher").click();
+  await expect(page.locator("#support-panel")).not.toHaveAttribute("hidden", "");
+  await expect(page.locator("#support-launcher")).toHaveAttribute("aria-expanded", "true");
+});
+
+test("si el opener termina de cargar después del render, el primer click se conserva", async ({ page }) => {
   await page.setContent(`
-    <!doctype html>
-    <html><head></head><body>
+    <!doctype html><html><body>
       <div id="kc-toast" hidden></div>
-      <section id="kc-stage-recommendations">
-        <button type="button" data-kc-path-open="comunicacion-clinica">Abrir recomendación</button>
-      </section>
+      <button id="late" type="button" data-kc-open-product="evidencia-aplicada">Abrir</button>
     </body></html>
   `);
-
   await page.evaluate(() => {
-    window.__recommended = [];
-    window.KINECHECK_OPEN_PRODUCT = async (product) => { window.__recommended.push(product); };
-    window.KINECHECK_RESET_PRODUCT_NAVIGATION = () => {};
+    window.__opened = [];
   });
-  await page.addScriptTag({ path: FIX_SCRIPT });
-
-  await page.locator('[data-kc-path-open="comunicacion-clinica"]').click();
-  await expect.poll(async () => page.evaluate(() => window.__recommended)).toEqual(["comunicacion-clinica"]);
-});
-
-test("al volver a Academy se libera cualquier estado de navegación", async ({ page }) => {
-  await page.setContent('<!doctype html><html><body><div id="kc-toast" hidden></div></body></html>');
+  await page.addScriptTag({ path: BRIDGE_SCRIPT });
+  await page.locator("#late").click();
+  await page.waitForTimeout(120);
   await page.evaluate(() => {
-    window.__navigationResets = 0;
-    window.KINECHECK_RESET_PRODUCT_NAVIGATION = () => { window.__navigationResets += 1; };
+    window.KINECHECK_OPEN_PRODUCT = async (slug) => window.__opened.push(slug);
   });
-  await page.addScriptTag({ path: FIX_SCRIPT });
-  await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true })));
-  await expect.poll(async () => page.evaluate(() => window.__navigationResets)).toBeGreaterThan(0);
+
+  await expect.poll(async () => page.evaluate(() => window.__opened), { timeout: 2000 }).toEqual([
+    "evidencia-aplicada",
+  ]);
 });

--- a/tests/owned-buttons.spec.mjs
+++ b/tests/owned-buttons.spec.mjs
@@ -13,7 +13,7 @@ async function installHarness(page) {
     <html><head></head><body data-kc-view="inicio" data-kc-experience="professional">
       <div id="kc-toast" hidden></div>
       <button id="mobile-menu" type="button" aria-expanded="false">Menu</button>
-      <div id="sidebar-overlay" hidden></div>
+      <div id="sidebar-overlay" hidden style="position:fixed;inset:0;z-index:10"></div>
       <aside id="academy-sidebar"></aside>
       <div id="support-panel" hidden></div>
       <button id="support-launcher" data-support-open aria-expanded="false">Soporte</button>


### PR DESCRIPTION
Corrige la regresión global de botones de Mi KineCheck eliminando la arquitectura de click proxy.

Cambios:
- todos los puntos de entrada de producto (`data-kc-open-product`, `data-kc-open-owned`, `data-kc-path-open`, `data-course`, Continuar) enrutan directamente al opener canónico;
- ya no se simula `target.click()` sobre otra tarjeta oculta;
- Mis productos, Recursos, Cuenta y ayuda, navegación simplificada, menú móvil, overlay lateral y soporte tienen fallback directo en captura;
- `academy-open-v6.js` se carga antes del controlador de navegación;
- se elimina la carga del listener redundante de recomendaciones para evitar competencia entre handlers;
- Playwright prueba todos los tipos de botones, Continuar, navegación móvil, soporte, primer click antes de que termine de cargar el opener y verifica que no exista click proxy;
- CI ahora se activa cuando cambia el bridge.

No modifica Auth, Supabase, `course_access`, compras, webhooks, SSO backend, usuarios, licencias ni secretos.