### PR TITLE
Test role UX through direct Academy navigation

### DIFF
--- a/.github/workflows/validate-unified-experience.yml
+++ b/.github/workflows/validate-unified-experience.yml
@@ -1,6 +1,26 @@
 name: Validar experiencia unificada Mi KineCheck
 
 on:
+  pull_request:
+    paths:
+      - "home.js"
+      - "home-experience-unification-v1.js"
+      - "home-experience-unification-v1.css"
+      - "productos/product-clinico-reposition-v1.js"
+      - "productos/product-experience-unification-v1.js"
+      - "productos/product-experience-unification-v1.css"
+      - "academy/academy-owned-native-bridge-v1.js"
+      - "academy/academy-brand-identity.js"
+      - "academy/mi-kinecheck-v1.js"
+      - "academy/mi-kinecheck-card-copy-v1.js"
+      - "academy/mi-kinecheck-v1.css"
+      - "academy/mi-kinecheck-simplify-v2.js"
+      - "academy/mi-kinecheck-simplify-v2.css"
+      - "platform/index.html"
+      - "platform/redirect-to-mi-kinecheck-v1.js"
+      - "tests/launch-readiness-public.spec.mjs"
+      - "tests/mi-kinecheck-roles.spec.mjs"
+      - ".github/workflows/validate-unified-experience.yml"
   push:
     branches: [main]
     paths:
@@ -10,6 +30,7 @@ on:
       - "productos/product-clinico-reposition-v1.js"
       - "productos/product-experience-unification-v1.js"
       - "productos/product-experience-unification-v1.css"
+      - "academy/academy-owned-native-bridge-v1.js"
       - "academy/academy-brand-identity.js"
       - "academy/mi-kinecheck-v1.js"
       - "academy/mi-kinecheck-card-copy-v1.js"
@@ -27,7 +48,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: validate-unified-experience
+  group: validate-unified-experience-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -91,6 +112,7 @@ jobs:
         run: node tests/mi-kinecheck-roles.spec.mjs
 
       - name: Validar producción en tres tamaños
+        if: github.event_name != 'pull_request'
         env:
           BASE_URL: https://kinecheck.cl
         run: |

--- a/tests/mi-kinecheck-roles.spec.mjs
+++ b/tests/mi-kinecheck-roles.spec.mjs
@@ -8,7 +8,7 @@ function fixture(slugs) {
   return `<!doctype html><html><head><meta name="description" content=""></head><body>
     <section id="login-view" hidden></section>
     <section id="dashboard-view">
-      <aside class="academy-sidebar">
+      <aside id="academy-sidebar" class="academy-sidebar">
         <nav class="sidebar-nav">
           <a data-kc-view-link="inicio"><span>⌂</span><span>Inicio</span></a>
           <a data-kc-view-link="biblioteca"><span>▤</span><span>Biblioteca</span></a>
@@ -18,7 +18,8 @@ function fixture(slugs) {
         <button class="kc-explore-link"><span>Explorar KineCheck</span></button>
         <div class="sidebar-account"><span id="sidebar-access">Cuenta activa</span><small id="sidebar-email">test@example.invalid</small></div>
       </aside>
-      <header class="topbar"><nav>
+      <div id="sidebar-overlay" hidden></div>
+      <header class="topbar"><button id="mobile-menu" aria-expanded="false">Menú</button><nav>
         <a data-kc-view-link="inicio">Inicio</a><a data-kc-view-link="biblioteca">Biblioteca</a><a data-kc-view-link="herramientas">Herramientas</a><a data-kc-view-link="perfil">Perfil</a>
       </nav></header>
       <main>
@@ -33,6 +34,7 @@ function fixture(slugs) {
         ${buttons}
       </main>
     </section>
+    <div id="support-panel" hidden></div><button id="support-launcher" data-support-open>Soporte</button>
     <div id="kc-toast" hidden></div>
   </body></html>`;
 }
@@ -44,9 +46,9 @@ async function pageFor(slugs) {
   await page.evaluate((courses) => {
     window.KINECHECK_ACADEMY_CONFIG = { ownerEmails: [], courses: courses.map((slug) => ({ slug, title: slug, subtitle: slug, kind: slug.includes("estudiante") || slug.includes("recupera") ? "application" : "course" })) };
     window.__opened = [];
-    document.querySelectorAll("[data-course]").forEach((button) => button.addEventListener("click", () => window.__opened.push(button.dataset.course)));
-    document.querySelectorAll("[data-kc-view-link]").forEach((link) => link.addEventListener("click", () => { window.__lastView = link.dataset.kcViewLink; }));
+    window.KINECHECK_OPEN_PRODUCT = async (slug) => { window.__opened.push(slug); };
   }, slugs);
+  await page.addScriptTag({ path: "academy/academy-owned-native-bridge-v1.js" });
   await page.addScriptTag({ path: "academy/mi-kinecheck-v1.js" });
   await page.waitForTimeout(220);
   await page.addScriptTag({ path: "academy/mi-kinecheck-simplify-v2.js" });
@@ -91,7 +93,7 @@ try {
     await context.close();
   }
 
-  console.log("Mi KineCheck role UX: 3/3 perfiles aprobados.");
+  console.log("Mi KineCheck role UX: 3/3 perfiles aprobados con controlador directo.");
 } finally {
   await browser.close();
 }

--- a/tests/mi-kinecheck-roles.spec.mjs
+++ b/tests/mi-kinecheck-roles.spec.mjs
@@ -31,7 +31,7 @@ function fixture(slugs) {
         <section class="kc-home-section"><h2 id="home-news-title">Noticias</h2></section>
         <section id="biblioteca"></section><section id="herramientas"></section><section id="perfil"></section><section id="cuenta"><div class="kc-page-heading"></div></section>
         <section id="kc-learning-path"></section><section id="kc-profile-stage"></section><button id="kc-sidebar-stage"></button><button id="kc-topbar-stage"></button><div id="kc-stage-modal"></div>
-        ${buttons}
+        <section id="course-grid">${buttons}</section>
       </main>
     </section>
     <div id="support-panel" hidden></div><button id="support-launcher" data-support-open>Soporte</button>


### PR DESCRIPTION
Actualiza únicamente la prueba de perfiles de Mi KineCheck para la arquitectura directa ya publicada.

La prueba anterior esperaba que `mi-kinecheck-simplify-v2.js` abriera productos por sí solo. Ese listener fue retirado deliberadamente para evitar controladores de clic duplicados.

Ahora la prueba:
- carga `academy-owned-native-bridge-v1.js`, el controlador global real;
- mantiene `mi-kinecheck-v1.js` y `mi-kinecheck-simplify-v2.js` como capas de presentación/rol;
- verifica que paciente abre Recupera mediante el controlador directo;
- verifica que estudiante abre Estudiante mediante el controlador directo;
- conserva las comprobaciones visuales de paciente, estudiante y profesional.

Es un cambio exclusivamente de test. No modifica código de producción, Auth, Supabase, course_access, compras, webhooks, SSO, usuarios, licencias ni secretos.