### PR TITLE
Align end-to-end healthcheck with direct session handoff

### DIFF
--- a/.github/workflows/kinecheck-healthcheck.yml
+++ b/.github/workflows/kinecheck-healthcheck.yml
@@ -1,6 +1,12 @@
 name: KineCheck healthcheck
 
 on:
+  pull_request:
+    paths:
+      - "academy/**"
+      - "kinecheck/**"
+      - "scripts/healthcheck.mjs"
+      - ".github/workflows/kinecheck-healthcheck.yml"
   push:
     branches: [main]
     paths:
@@ -15,6 +21,10 @@ on:
 permissions:
   contents: read
   issues: write
+
+concurrency:
+  group: kinecheck-healthcheck-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   end-to-end-healthcheck:
@@ -50,6 +60,7 @@ jobs:
           exit 0
 
       - name: Publish healthcheck report
+        if: github.event_name != 'pull_request'
         uses: actions/github-script@v7
         env:
           HEALTHCHECK_EXIT_CODE: ${{ steps.healthcheck.outputs.exit_code }}

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -243,10 +243,16 @@ async function main() {
     logFail("El opener unificado no utiliza la ruta protegida de Comunicación Clínica.");
   } else if (!opener.includes("KINECHECK_ACADEMY_SESSION?.refresh")) {
     logFail("El opener unificado no intenta renovar una sesión vencida.");
-  } else if (!opener.includes("popup.name = JSON.stringify(transfer)")) {
-    logFail("El opener unificado no conserva el respaldo del traspaso para cursos externos.");
+  } else if (
+    !opener.includes("kc_handoff")
+    || !opener.includes("externalHandoffUrl")
+    || !opener.includes("location.assign(externalHandoffUrl(targetUrl, session, product))")
+    || !opener.includes("handoff_access_only: true")
+    || opener.includes("popup.name = JSON.stringify(transfer)")
+  ) {
+    logFail("El opener unificado no conserva el handoff efímero access-only vigente para cursos externos.");
   } else {
-    logOk("El opener unificado mantiene ruta protegida, renovación y traspaso de sesión.");
+    logOk("El opener unificado mantiene ruta protegida, renovación y handoff efímero access-only sin popup.");
   }
 
   if (!courseAuthGate.includes('COURSE_SESSION_PREFIX = "kinecheck_course_session_v2:"')) {


### PR DESCRIPTION
Actualiza el último validador obsoleto después de la corrección global de botones.

El healthcheck integral seguía exigiendo `popup.name = JSON.stringify(transfer)`, mecanismo retirado para que los cursos externos funcionen también en navegación privada/Safari.

Cambios:
- exige el handoff efímero vigente (`kc_handoff`, `externalHandoffUrl`, `location.assign`, `handoff_access_only`);
- rechaza expresamente el respaldo antiguo por `popup.name`;
- conserva todas las demás comprobaciones de checkout, rutas públicas, Academy, productos, Supabase y webhooks;
- el healthcheck ahora se ejecuta también como gate de pull request cuando cambian Academy o el propio healthcheck;
- en PR no modifica el issue/informe automático; solo valida.

No modifica lógica de producción, Auth, Supabase, course_access, compras, webhooks, SSO backend, usuarios, licencias ni secretos.