### PR TITLE
Diagnose and harden live Academy buttons on Safari

### DIFF
--- a/.github/workflows/validate-recommended-buttons.yml
+++ b/.github/workflows/validate-recommended-buttons.yml
@@ -76,16 +76,31 @@ jobs:
         run: npx playwright test tests/recommended-buttons.spec.mjs tests/owned-buttons.spec.mjs --reporter=line
 
       - name: Test Academy runtime in Chromium
+        id: chromium_gate
         if: always()
+        continue-on-error: true
         env:
           BASE_URL: ${{ github.event_name == 'pull_request' && 'http://127.0.0.1:4173' || 'https://kinecheck.cl' }}
         run: npx playwright test tests/live-academy-runtime.spec.mjs --browser=chromium --reporter=line
 
       - name: Test Academy runtime in WebKit
+        id: webkit_gate
         if: always()
+        continue-on-error: true
         env:
           BASE_URL: ${{ github.event_name == 'pull_request' && 'http://127.0.0.1:4173' || 'https://kinecheck.cl' }}
         run: npx playwright test tests/live-academy-runtime.spec.mjs --browser=webkit --reporter=line
+
+      - name: Enforce Chromium and WebKit gates
+        if: always()
+        env:
+          CHROMIUM_OUTCOME: ${{ steps.chromium_gate.outcome }}
+          WEBKIT_OUTCOME: ${{ steps.webkit_gate.outcome }}
+        run: |
+          echo "Chromium: ${CHROMIUM_OUTCOME}"
+          echo "WebKit: ${WEBKIT_OUTCOME}"
+          test "${CHROMIUM_OUTCOME}" = "success"
+          test "${WEBKIT_OUTCOME}" = "success"
 
       - name: Upload browser evidence
         if: always()

--- a/.github/workflows/validate-recommended-buttons.yml
+++ b/.github/workflows/validate-recommended-buttons.yml
@@ -60,17 +60,31 @@ jobs:
           npm install --no-save @playwright/test@1.55.0
           npx playwright install --with-deps chromium webkit
 
+      - name: Serve exact pull request checkout
+        if: github.event_name == 'pull_request'
+        run: |
+          python3 -m http.server 4173 --bind 127.0.0.1 >/tmp/kinecheck-http.log 2>&1 &
+          echo $! >/tmp/kinecheck-http.pid
+          sleep 2
+          curl --fail --silent http://127.0.0.1:4173/academy/ >/dev/null
+
+      - name: Wait for production deployment
+        if: github.event_name == 'push'
+        run: sleep 60
+
       - name: Test recommendation and owned product buttons
         run: npx playwright test tests/recommended-buttons.spec.mjs tests/owned-buttons.spec.mjs --reporter=line
 
-      - name: Test live Academy runtime in Chromium
+      - name: Test Academy runtime in Chromium
+        if: always()
         env:
-          BASE_URL: https://kinecheck.cl
+          BASE_URL: ${{ github.event_name == 'pull_request' && 'http://127.0.0.1:4173' || 'https://kinecheck.cl' }}
         run: npx playwright test tests/live-academy-runtime.spec.mjs --browser=chromium --reporter=line
 
-      - name: Test live Academy runtime in WebKit
+      - name: Test Academy runtime in WebKit
+        if: always()
         env:
-          BASE_URL: https://kinecheck.cl
+          BASE_URL: ${{ github.event_name == 'pull_request' && 'http://127.0.0.1:4173' || 'https://kinecheck.cl' }}
         run: npx playwright test tests/live-academy-runtime.spec.mjs --browser=webkit --reporter=line
 
       - name: Upload browser evidence

--- a/.github/workflows/validate-recommended-buttons.yml
+++ b/.github/workflows/validate-recommended-buttons.yml
@@ -15,6 +15,7 @@ on:
       - 'academy/mi-kinecheck-simplify-v2.js'
       - 'tests/recommended-buttons.spec.mjs'
       - 'tests/owned-buttons.spec.mjs'
+      - 'tests/live-academy-runtime.spec.mjs'
       - '.github/workflows/validate-recommended-buttons.yml'
   push:
     branches: [main]
@@ -30,6 +31,7 @@ on:
       - 'academy/mi-kinecheck-simplify-v2.js'
       - 'tests/recommended-buttons.spec.mjs'
       - 'tests/owned-buttons.spec.mjs'
+      - 'tests/live-academy-runtime.spec.mjs'
       - '.github/workflows/validate-recommended-buttons.yml'
 
 permissions:
@@ -42,7 +44,7 @@ concurrency:
 jobs:
   browser-buttons:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     steps:
       - name: Checkout repository
@@ -56,10 +58,20 @@ jobs:
       - name: Install Playwright
         run: |
           npm install --no-save @playwright/test@1.55.0
-          npx playwright install --with-deps chromium
+          npx playwright install --with-deps chromium webkit
 
       - name: Test recommendation and owned product buttons
         run: npx playwright test tests/recommended-buttons.spec.mjs tests/owned-buttons.spec.mjs --reporter=line
+
+      - name: Test live Academy runtime in Chromium
+        env:
+          BASE_URL: https://kinecheck.cl
+        run: npx playwright test tests/live-academy-runtime.spec.mjs --browser=chromium --reporter=line
+
+      - name: Test live Academy runtime in WebKit
+        env:
+          BASE_URL: https://kinecheck.cl
+        run: npx playwright test tests/live-academy-runtime.spec.mjs --browser=webkit --reporter=line
 
       - name: Upload browser evidence
         if: always()

--- a/academy/academy-owned-native-bridge-v1.js
+++ b/academy/academy-owned-native-bridge-v1.js
@@ -4,12 +4,13 @@
   if (window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__) return;
   window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__ = true;
 
+  // Solo intercepta entradas proxy creadas por Inicio, Mi KineCheck y recomendaciones.
+  // Los botones nativos de #course-grid y #continue-button deben conservar sus
+  // listeners de academy-v39.js y no ser bloqueados por este bridge.
   const PRODUCT_SELECTOR = [
     "[data-kc-open-product]",
     "[data-kc-open-owned]",
     "[data-kc-path-open]",
-    "#course-grid [data-course]",
-    "#continue-button[data-course]",
   ].join(", ");
 
   const STUDENT_ORDER = [
@@ -89,12 +90,23 @@
     });
   }
 
+  function nativeOpenCourse() {
+    if (typeof window.KINECHECK_ACADEMY_OPEN_COURSE === "function") {
+      return window.KINECHECK_ACADEMY_OPEN_COURSE;
+    }
+    // academy-v39.js es un script clásico; su función openCourse queda disponible
+    // en window. Este fallback conecta el bridge con el flujo nativo validado.
+    if (typeof window.openCourse === "function") return window.openCourse;
+    return null;
+  }
+
   async function openSlug(slug, source) {
     if (!slug) return;
 
     try {
-      if (typeof window.KINECHECK_ACADEMY_OPEN_COURSE === "function") {
-        await window.KINECHECK_ACADEMY_OPEN_COURSE(slug);
+      const native = nativeOpenCourse();
+      if (native) {
+        await native(slug);
         return;
       }
 
@@ -106,8 +118,9 @@
       const startedAt = Date.now();
       while (Date.now() - startedAt < 4000) {
         await new Promise((resolve) => window.setTimeout(resolve, 40));
-        if (typeof window.KINECHECK_ACADEMY_OPEN_COURSE === "function") {
-          await window.KINECHECK_ACADEMY_OPEN_COURSE(slug);
+        const delayedNative = nativeOpenCourse();
+        if (delayedNative) {
+          await delayedNative(slug);
           return;
         }
         if (typeof window.KINECHECK_OPEN_PRODUCT === "function") {

--- a/tests/live-academy-runtime.spec.mjs
+++ b/tests/live-academy-runtime.spec.mjs
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.BASE_URL || "https://kinecheck.cl";
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+test("Academy real carga opener y bridge y responde a clicks directos", async ({ page }) => {
+  const consoleErrors = [];
+  page.on("console", (message) => {
+    if (message.type() !== "error") return;
+    const text = `${message.text()} ${message.location().url || ""}`;
+    if (/favicon|metric-event|cloudflareinsights\.com|static\.cloudflareinsights\.com|beacon\.min\.js/i.test(text)) return;
+    consoleErrors.push(text);
+  });
+
+  await page.goto(`${BASE}/academy/?qa=live-runtime-${Date.now()}`, {
+    waitUntil: "domcontentloaded",
+    timeout: 30000,
+  });
+
+  await expect.poll(async () => page.evaluate(() => ({
+    opener: typeof window.KINECHECK_OPEN_PRODUCT,
+    bridge: window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__ === true,
+    scripts: [...document.scripts].map((script) => script.src).filter(Boolean),
+  })), { timeout: 10000 }).toMatchObject({ opener: "function", bridge: true });
+
+  const runtime = await page.evaluate(() => ({
+    opener: typeof window.KINECHECK_OPEN_PRODUCT,
+    bridge: window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__ === true,
+    scripts: [...document.scripts].map((script) => script.src).filter(Boolean),
+  }));
+
+  expect(runtime.scripts.some((src) => src.includes("academy-brand-identity.js"))).toBeTruthy();
+  expect(runtime.scripts.some((src) => src.includes("academy-open-v6.js"))).toBeTruthy();
+  expect(runtime.scripts.some((src) => src.includes("academy-owned-native-bridge-v1.js"))).toBeTruthy();
+
+  await page.evaluate(() => {
+    const login = document.querySelector("#login-view");
+    const dashboard = document.querySelector("#dashboard-view");
+    if (login) login.hidden = true;
+    if (dashboard) dashboard.hidden = false;
+
+    window.__runtimeOpened = [];
+    window.__realKineCheckOpenProduct = window.KINECHECK_OPEN_PRODUCT;
+    window.KINECHECK_OPEN_PRODUCT = async (slug) => {
+      window.__runtimeOpened.push(slug);
+    };
+
+    const probe = document.createElement("div");
+    probe.id = "qa-runtime-probe";
+    probe.innerHTML = `
+      <button id="qa-product" type="button" data-kc-open-product="comunicacion-clinica">Abrir curso</button>
+      <button id="qa-view" type="button" data-kc-view-link="biblioteca">Mis productos</button>
+    `;
+    document.body.appendChild(probe);
+  });
+
+  await page.locator("#qa-product").click();
+  await expect.poll(async () => page.evaluate(() => window.__runtimeOpened)).toEqual(["comunicacion-clinica"]);
+
+  await page.locator("#qa-view").click();
+  await expect(page.locator("body")).toHaveAttribute("data-kc-view", "biblioteca");
+  await expect.poll(async () => page.evaluate(() => location.hash)).toBe("#biblioteca");
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/tests/live-academy-runtime.spec.mjs
+++ b/tests/live-academy-runtime.spec.mjs
@@ -1,8 +1,15 @@
 import { test, expect } from "@playwright/test";
 
 const BASE = process.env.BASE_URL || "https://kinecheck.cl";
+const LOCAL_HARNESS = /^http:\/\/127\.0\.0\.1:4173(?:\/|$)/i.test(BASE);
 
 test.use({ viewport: { width: 390, height: 844 } });
+
+function isExpectedHarnessNoise(text) {
+  if (!LOCAL_HARNESS) return false;
+  return /Origin http:\/\/127\.0\.0\.1:4173 is not allowed by Access-Control-Allow-Origin/i.test(text)
+    || /http:\/\/127\.0\.0\.1:4173\/api\/health(?:\s|$|\?)/i.test(text);
+}
 
 test("Academy real carga el bridge y conecta tarjetas proxy con openCourse nativo", async ({ page }) => {
   const consoleErrors = [];
@@ -10,6 +17,7 @@ test("Academy real carga el bridge y conecta tarjetas proxy con openCourse nativ
     if (message.type() !== "error") return;
     const text = `${message.text()} ${message.location().url || ""}`;
     if (/favicon|metric-event|cloudflareinsights\.com|static\.cloudflareinsights\.com|beacon\.min\.js/i.test(text)) return;
+    if (isExpectedHarnessNoise(text)) return;
     consoleErrors.push(text);
   });
 

--- a/tests/live-academy-runtime.spec.mjs
+++ b/tests/live-academy-runtime.spec.mjs
@@ -4,7 +4,7 @@ const BASE = process.env.BASE_URL || "https://kinecheck.cl";
 
 test.use({ viewport: { width: 390, height: 844 } });
 
-test("Academy real carga opener y bridge y responde a clicks directos", async ({ page }) => {
+test("Academy real carga el bridge y conecta tarjetas proxy con openCourse nativo", async ({ page }) => {
   const consoleErrors = [];
   page.on("console", (message) => {
     if (message.type() !== "error") return;
@@ -20,19 +20,20 @@ test("Academy real carga opener y bridge y responde a clicks directos", async ({
 
   await expect.poll(async () => page.evaluate(() => ({
     opener: typeof window.KINECHECK_OPEN_PRODUCT,
+    native: typeof window.openCourse,
     bridge: window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__ === true,
-    scripts: [...document.scripts].map((script) => script.src).filter(Boolean),
-  })), { timeout: 10000 }).toMatchObject({ opener: "function", bridge: true });
+  })), { timeout: 10000 }).toEqual({ opener: "function", native: "function", bridge: true });
 
   const runtime = await page.evaluate(() => ({
-    opener: typeof window.KINECHECK_OPEN_PRODUCT,
-    bridge: window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__ === true,
     scripts: [...document.scripts].map((script) => script.src).filter(Boolean),
+    watermarkPointerEvents: document.querySelector("#kinecheck-dynamic-watermark")
+      ? getComputedStyle(document.querySelector("#kinecheck-dynamic-watermark")).pointerEvents
+      : "not-rendered",
   }));
-
   expect(runtime.scripts.some((src) => src.includes("academy-brand-identity.js"))).toBeTruthy();
   expect(runtime.scripts.some((src) => src.includes("academy-open-v6.js"))).toBeTruthy();
   expect(runtime.scripts.some((src) => src.includes("academy-owned-native-bridge-v1.js"))).toBeTruthy();
+  expect(["none", "not-rendered"]).toContain(runtime.watermarkPointerEvents);
 
   await page.evaluate(() => {
     const login = document.querySelector("#login-view");
@@ -41,26 +42,65 @@ test("Academy real carga opener y bridge y responde a clicks directos", async ({
     if (dashboard) dashboard.hidden = false;
 
     window.__runtimeOpened = [];
-    window.__realKineCheckOpenProduct = window.KINECHECK_OPEN_PRODUCT;
-    window.KINECHECK_OPEN_PRODUCT = async (slug) => {
+    window.__originalOpenCourse = window.openCourse;
+    window.openCourse = async (slug) => {
       window.__runtimeOpened.push(slug);
     };
 
-    const probe = document.createElement("div");
-    probe.id = "qa-runtime-probe";
-    probe.innerHTML = `
-      <button id="qa-product" type="button" data-kc-open-product="comunicacion-clinica">Abrir curso</button>
-      <button id="qa-view" type="button" data-kc-view-link="biblioteca">Mis productos</button>
-    `;
-    document.body.appendChild(probe);
+    const host = document.querySelector("#inicio .kc-home-actions");
+    const probe = document.createElement("button");
+    probe.id = "qa-product";
+    probe.type = "button";
+    probe.dataset.kcOpenProduct = "comunicacion-clinica";
+    probe.textContent = "Abrir curso QA";
+    host?.appendChild(probe);
   });
 
+  await page.locator("#qa-product").evaluate((element) => element.scrollIntoView({ block: "center", inline: "center" }));
   await page.locator("#qa-product").click();
   await expect.poll(async () => page.evaluate(() => window.__runtimeOpened)).toEqual(["comunicacion-clinica"]);
+  expect(consoleErrors).toEqual([]);
+});
 
-  await page.locator("#qa-view").click();
+test("navegación móvil real y botones nativos conservan eventos de puntero", async ({ page }) => {
+  await page.goto(`${BASE}/academy/?qa=live-pointer-${Date.now()}`, {
+    waitUntil: "domcontentloaded",
+    timeout: 30000,
+  });
+  await expect.poll(async () => page.evaluate(() => window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__ === true), { timeout: 10000 }).toBe(true);
+
+  await page.evaluate(() => {
+    document.querySelector("#login-view")?.setAttribute("hidden", "");
+    const dashboard = document.querySelector("#dashboard-view");
+    if (dashboard) dashboard.hidden = false;
+    window.__nativePointerEvents = [];
+
+    const grid = document.querySelector("#course-grid");
+    if (grid) {
+      const probe = document.createElement("button");
+      probe.id = "qa-native-course";
+      probe.type = "button";
+      probe.dataset.course = "qa-native-course";
+      probe.textContent = "Curso nativo QA";
+      grid.prepend(probe);
+      grid.addEventListener("click", (event) => {
+        if (event.target.closest("#qa-native-course")) window.__nativePointerEvents.push("course-grid");
+      });
+    }
+  });
+
+  const bottomProducts = page.locator('#kc-bottom-nav [data-kc-view-link="biblioteca"]');
+  await expect(bottomProducts).toBeVisible();
+  await bottomProducts.click();
   await expect(page.locator("body")).toHaveAttribute("data-kc-view", "biblioteca");
   await expect.poll(async () => page.evaluate(() => location.hash)).toBe("#biblioteca");
 
-  expect(consoleErrors).toEqual([]);
+  await page.locator("#qa-native-course").evaluate((element) => element.scrollIntoView({ block: "center", inline: "center" }));
+  await page.locator("#qa-native-course").click();
+  await expect.poll(async () => page.evaluate(() => window.__nativePointerEvents)).toEqual(["course-grid"]);
+
+  const menu = page.locator("#mobile-menu");
+  await menu.click();
+  await expect(page.locator("#academy-sidebar")).toHaveClass(/open/);
+  await expect(menu).toHaveAttribute("aria-expanded", "true");
 });

--- a/tests/owned-buttons.spec.mjs
+++ b/tests/owned-buttons.spec.mjs
@@ -48,44 +48,67 @@ async function installHarness(page) {
   `);
 
   await page.evaluate(() => {
-    window.__opened = [];
-    window.__courseGridProxyClicks = 0;
-    window.KINECHECK_OPEN_PRODUCT = async (slug) => {
-      window.__opened.push(slug);
+    window.__openedCore = [];
+    window.__openedFallback = [];
+    window.__nativeGridClicks = [];
+    window.__nativeContinueClicks = [];
+
+    // academy-v39.js expone openCourse como función global en script clásico.
+    window.openCourse = async (slug) => {
+      window.__openedCore.push(slug);
     };
-    document.querySelector("#course-grid").addEventListener("click", () => {
-      window.__courseGridProxyClicks += 1;
+    window.KINECHECK_OPEN_PRODUCT = async (slug) => {
+      window.__openedFallback.push(slug);
+    };
+
+    document.querySelector("#course-grid").addEventListener("click", (event) => {
+      const button = event.target.closest("[data-course]");
+      if (button) window.__nativeGridClicks.push(button.dataset.course);
+    });
+    document.querySelector("#continue-button").addEventListener("click", (event) => {
+      window.__nativeContinueClicks.push(event.currentTarget.dataset.course);
     });
   });
 
   await page.addScriptTag({ path: BRIDGE_SCRIPT });
 }
 
-test("todos los puntos de entrada abren el producto directamente, sin click proxy", async ({ page }) => {
+test("tarjetas proxy usan el controlador nativo de Academy, no el opener alternativo", async ({ page }) => {
   await installHarness(page);
 
   await page.locator("#home-clinico").click();
   await page.locator("#owned-student").click();
   await page.locator("#recommended-pain").click();
-  await page.locator('#course-grid [data-course="comunicacion-clinica"]').click();
-  await page.locator('#course-grid [data-course="kinecheck-clinico-curso"]').click();
   await page.locator("#home-recupera").click();
-  await page.locator("#continue-button").click();
 
-  await expect.poll(async () => page.evaluate(() => window.__opened)).toEqual([
+  await expect.poll(async () => page.evaluate(() => window.__openedCore)).toEqual([
     "kinecheck-clinico",
     "kinecheck-estudiante",
     "mas-alla-del-dolor",
-    "comunicacion-clinica",
-    "kinecheck-clinico-curso",
     "kinecheck-recupera",
-    "evidencia-aplicada",
   ]);
-
-  await expect.poll(async () => page.evaluate(() => window.__courseGridProxyClicks)).toBe(0);
+  await expect.poll(async () => page.evaluate(() => window.__openedFallback)).toEqual([]);
 });
 
-test("Continuar actividad usa el producto recordado sin depender de otro listener", async ({ page }) => {
+test("botones nativos de course-grid y Continuar no son interceptados por el bridge", async ({ page }) => {
+  await installHarness(page);
+
+  await page.locator('#course-grid [data-course="comunicacion-clinica"]').click();
+  await page.locator('#course-grid [data-course="kinecheck-clinico-curso"]').click();
+  await page.locator("#continue-button").click();
+
+  await expect.poll(async () => page.evaluate(() => window.__nativeGridClicks)).toEqual([
+    "comunicacion-clinica",
+    "kinecheck-clinico-curso",
+  ]);
+  await expect.poll(async () => page.evaluate(() => window.__nativeContinueClicks)).toEqual([
+    "evidencia-aplicada",
+  ]);
+  await expect.poll(async () => page.evaluate(() => window.__openedCore)).toEqual([]);
+  await expect.poll(async () => page.evaluate(() => window.__openedFallback)).toEqual([]);
+});
+
+test("Continuar actividad usa el controlador nativo con el producto recordado", async ({ page }) => {
   await installHarness(page);
 
   await page.evaluate(() => {
@@ -93,9 +116,10 @@ test("Continuar actividad usa el producto recordado sin depender de otro listene
   });
   await page.locator("#kc-home-continue").click();
 
-  await expect.poll(async () => page.evaluate(() => window.__opened)).toEqual([
+  await expect.poll(async () => page.evaluate(() => window.__openedCore)).toEqual([
     "traumatologia-ortopedia-clinica",
   ]);
+  await expect.poll(async () => page.evaluate(() => window.__openedFallback)).toEqual([]);
 });
 
 test("Mis productos, Recursos, Cuenta y navegación móvil funcionan desde el controlador directo", async ({ page }) => {
@@ -132,7 +156,7 @@ test("Soporte responde aunque los listeners secundarios no carguen", async ({ pa
   await expect(page.locator("#support-launcher")).toHaveAttribute("aria-expanded", "true");
 });
 
-test("si el opener termina de cargar después del render, el primer click se conserva", async ({ page }) => {
+test("si el controlador nativo no existe, conserva el fallback del opener", async ({ page }) => {
   await page.setContent(`
     <!doctype html><html><body>
       <div id="kc-toast" hidden></div>


### PR DESCRIPTION
Reproduce el fallo real reportado en producción en vez de confiar solo en fixtures. Añade una prueba que abre `https://kinecheck.cl/academy/` como página real, verifica que `academy-brand-identity`, `academy-open-v6` y `academy-owned-native-bridge-v1` estén realmente cargados, y prueba clicks directos de producto y navegación. Se ejecuta tanto en Chromium como en WebKit para cubrir el comportamiento equivalente a Safari/iPhone. No modifica Auth, Supabase, licencias, compras, webhooks, SSO backend, usuarios ni secretos.