### PR TITLE
Fix owned Academy cards with the unified product opener

### DIFF
--- a/.github/workflows/validate-recommended-buttons.yml
+++ b/.github/workflows/validate-recommended-buttons.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - 'metrics-v1.js'
       - 'academy/academy-open-v6.js'
       - 'academy/academy-owned-native-bridge-v1.js'
       - 'academy/academy-recommended-buttons-fix.js'
@@ -20,6 +21,7 @@ on:
   push:
     branches: [main]
     paths:
+      - 'metrics-v1.js'
       - 'academy/academy-open-v6.js'
       - 'academy/academy-owned-native-bridge-v1.js'
       - 'academy/academy-recommended-buttons-fix.js'

--- a/academy/academy-brand-identity.js
+++ b/academy/academy-brand-identity.js
@@ -85,11 +85,11 @@
   loadScript("../assets/runtime-config.js", "data-kc-runtime", "20260807-1");
   loadScript("../assets/observability.js", "data-kc-observability", "20260807-1");
   loadScript("./security-hardening-v1.js", "data-kc-security-hardening", "20260807-1");
-  loadScript("../metrics-v1.js", "data-kc-launch-metrics", "20260806-launch-metrics1");
+  loadScript("../metrics-v1.js", "data-kc-launch-metrics", "20260809-ownedopener1");
 
   // Orden deliberado: primero existe un único opener; luego el controlador de clicks.
   loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260809-directnav1");
-  loadScript("./academy-owned-native-bridge-v1.js", "data-kc-owned-native-bridge", "20260809-directnav1");
+  loadScript("./academy-owned-native-bridge-v1.js", "data-kc-owned-native-bridge", "20260809-ownedopener1");
 
   loadScript("./mi-kinecheck-v1.js", "data-mi-kinecheck", "20260809-directnav2");
   loadScript("./mi-kinecheck-card-copy-v1.js", "data-mi-kinecheck-card-copy", "20260806-unified1");

--- a/academy/academy-owned-native-bridge-v1.js
+++ b/academy/academy-owned-native-bridge-v1.js
@@ -5,8 +5,9 @@
   window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__ = true;
 
   // Solo intercepta entradas proxy creadas por Inicio, Mi KineCheck y recomendaciones.
-  // Los botones nativos de #course-grid y #continue-button deben conservar sus
-  // listeners de academy-v39.js y no ser bloqueados por este bridge.
+  // Todas esas entradas deben usar el mismo opener unificado que ya funciona en las
+  // recomendaciones. Los botones nativos de #course-grid y #continue-button conservan
+  // sus listeners de academy-v39.js y su validación nativa.
   const PRODUCT_SELECTOR = [
     "[data-kc-open-product]",
     "[data-kc-open-owned]",
@@ -94,8 +95,6 @@
     if (typeof window.KINECHECK_ACADEMY_OPEN_COURSE === "function") {
       return window.KINECHECK_ACADEMY_OPEN_COURSE;
     }
-    // academy-v39.js es un script clásico; su función openCourse queda disponible
-    // en window. Este fallback conecta el bridge con el flujo nativo validado.
     if (typeof window.openCourse === "function") return window.openCourse;
     return null;
   }
@@ -104,12 +103,9 @@
     if (!slug) return;
 
     try {
-      const native = nativeOpenCourse();
-      if (native) {
-        await native(slug);
-        return;
-      }
-
+      // Las tarjetas proxy usan primero el opener unificado. Es la misma ruta que
+      // utilizan las recomendaciones: muestra estado "Abriendo…", renueva sesión
+      // cuando corresponde y deja un error visible en #kc-toast si no puede navegar.
       if (typeof window.KINECHECK_OPEN_PRODUCT === "function") {
         await window.KINECHECK_OPEN_PRODUCT(slug, source || null);
         return;
@@ -118,15 +114,17 @@
       const startedAt = Date.now();
       while (Date.now() - startedAt < 4000) {
         await new Promise((resolve) => window.setTimeout(resolve, 40));
-        const delayedNative = nativeOpenCourse();
-        if (delayedNative) {
-          await delayedNative(slug);
-          return;
-        }
         if (typeof window.KINECHECK_OPEN_PRODUCT === "function") {
           await window.KINECHECK_OPEN_PRODUCT(slug, source || null);
           return;
         }
+      }
+
+      // Fallback de resiliencia únicamente si el opener unificado no llegó a cargar.
+      const native = nativeOpenCourse();
+      if (native) {
+        await native(slug);
+        return;
       }
 
       throw new Error("El controlador de acceso no terminó de cargar.");

--- a/metrics-v1.js
+++ b/metrics-v1.js
@@ -98,7 +98,14 @@
     if (!target) return;
 
     const card = target.closest("[data-product-card]");
-    const slug = cleanProduct(card?.getAttribute("data-course") || target.getAttribute("data-course") || target.getAttribute("data-kc-path-open") || currentProduct());
+    const slug = cleanProduct(
+      card?.getAttribute("data-course")
+      || target.getAttribute("data-course")
+      || target.getAttribute("data-kc-path-open")
+      || target.getAttribute("data-kc-open-product")
+      || target.getAttribute("data-kc-open-owned")
+      || currentProduct(),
+    );
     const href = target instanceof HTMLAnchorElement ? target.href : "";
 
     if (href && /pay\.hotmart\.com/i.test(href)) {
@@ -111,7 +118,12 @@
       return;
     }
 
-    if (slug && (target.hasAttribute("data-course") || target.hasAttribute("data-kc-path-open") || target.hasAttribute("data-kc-open-product"))) {
+    if (slug && (
+      target.hasAttribute("data-course")
+      || target.hasAttribute("data-kc-path-open")
+      || target.hasAttribute("data-kc-open-product")
+      || target.hasAttribute("data-kc-open-owned")
+    )) {
       send("course_open", { productSlug: slug });
     }
   }, { capture: true });

--- a/tests/live-academy-runtime.spec.mjs
+++ b/tests/live-academy-runtime.spec.mjs
@@ -11,7 +11,7 @@ function isExpectedHarnessNoise(text) {
     || /http:\/\/127\.0\.0\.1:4173\/api\/health(?:\s|$|\?)/i.test(text);
 }
 
-test("Academy real carga el bridge y conecta tarjetas proxy con openCourse nativo", async ({ page }) => {
+function collectUnexpectedConsoleErrors(page) {
   const consoleErrors = [];
   page.on("console", (message) => {
     if (message.type() !== "error") return;
@@ -20,8 +20,11 @@ test("Academy real carga el bridge y conecta tarjetas proxy con openCourse nativ
     if (isExpectedHarnessNoise(text)) return;
     consoleErrors.push(text);
   });
+  return consoleErrors;
+}
 
-  await page.goto(`${BASE}/academy/?qa=live-runtime-${Date.now()}`, {
+async function openAcademy(page, label) {
+  await page.goto(`${BASE}/academy/?qa=${label}-${Date.now()}`, {
     waitUntil: "domcontentloaded",
     timeout: 30000,
   });
@@ -31,6 +34,11 @@ test("Academy real carga el bridge y conecta tarjetas proxy con openCourse nativ
     native: typeof window.openCourse,
     bridge: window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__ === true,
   })), { timeout: 10000 }).toEqual({ opener: "function", native: "function", bridge: true });
+}
+
+test("Mis productos usa el opener real y completa una navegación de curso", async ({ page }) => {
+  const consoleErrors = collectUnexpectedConsoleErrors(page);
+  await openAcademy(page, "owned-real-open");
 
   const runtime = await page.evaluate(() => ({
     scripts: [...document.scripts].map((script) => script.src).filter(Boolean),
@@ -43,39 +51,87 @@ test("Academy real carga el bridge y conecta tarjetas proxy con openCourse nativ
   expect(runtime.scripts.some((src) => src.includes("academy-owned-native-bridge-v1.js"))).toBeTruthy();
   expect(["none", "not-rendered"]).toContain(runtime.watermarkPointerEvents);
 
+  await page.route("**/comunicacion-clinica.html?*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html; charset=utf-8",
+      body: "<!doctype html><html><body><main id=qa-destination>Destino QA</main></body></html>",
+    });
+  });
+
   await page.evaluate(() => {
     const login = document.querySelector("#login-view");
     const dashboard = document.querySelector("#dashboard-view");
     if (login) login.hidden = true;
     if (dashboard) dashboard.hidden = false;
 
-    window.__runtimeOpened = [];
-    window.__originalOpenCourse = window.openCourse;
-    window.openCourse = async (slug) => {
-      window.__runtimeOpened.push(slug);
+    const session = {
+      access_token: "qa-access-token-for-runtime-navigation",
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      expires_in: 3600,
+      token_type: "bearer",
     };
+    window.KINECHECK_ACADEMY_SESSION = Object.freeze({
+      get: () => session,
+      refresh: async () => session,
+    });
 
     const host = document.querySelector("#inicio .kc-home-actions");
     const probe = document.createElement("button");
-    probe.id = "qa-product";
+    probe.id = "qa-owned-product";
     probe.type = "button";
-    probe.dataset.kcOpenProduct = "comunicacion-clinica";
-    probe.textContent = "Abrir curso QA";
+    probe.dataset.kcOpenOwned = "comunicacion-clinica";
+    probe.textContent = "Abrir curso adquirido QA";
     host?.appendChild(probe);
   });
 
-  await page.locator("#qa-product").evaluate((element) => element.scrollIntoView({ block: "center", inline: "center" }));
-  await page.locator("#qa-product").click();
-  await expect.poll(async () => page.evaluate(() => window.__runtimeOpened)).toEqual(["comunicacion-clinica"]);
+  const ownedButton = page.locator("#qa-owned-product");
+  await ownedButton.evaluate((element) => element.scrollIntoView({ block: "center", inline: "center" }));
+
+  await Promise.all([
+    page.waitForURL(/\/comunicacion-clinica\.html\?course=comunicacion-clinica/, { timeout: 10000 }),
+    ownedButton.click(),
+  ]);
+
+  await expect(page.locator("#qa-destination")).toHaveText("Destino QA");
+  expect(consoleErrors).toEqual([]);
+});
+
+test("Mis productos muestra un error visible si la sesión no permite navegar", async ({ page }) => {
+  const consoleErrors = collectUnexpectedConsoleErrors(page);
+  await openAcademy(page, "owned-visible-error");
+
+  await page.evaluate(() => {
+    document.querySelector("#login-view")?.setAttribute("hidden", "");
+    const dashboard = document.querySelector("#dashboard-view");
+    if (dashboard) dashboard.hidden = false;
+
+    localStorage.removeItem("kinecheck_secure_session_v1");
+    sessionStorage.removeItem("kinecheck_secure_session_v1");
+    window.KINECHECK_ACADEMY_SESSION = Object.freeze({
+      get: () => null,
+      refresh: async () => null,
+    });
+
+    const host = document.querySelector("#inicio .kc-home-actions");
+    const probe = document.createElement("button");
+    probe.id = "qa-owned-no-session";
+    probe.type = "button";
+    probe.dataset.kcOpenOwned = "comunicacion-clinica";
+    probe.textContent = "Abrir sin sesión QA";
+    host?.appendChild(probe);
+  });
+
+  const button = page.locator("#qa-owned-no-session");
+  await button.click();
+  await expect(page.locator("#kc-toast")).toBeVisible();
+  await expect(page.locator("#kc-toast")).toContainText(/sesión/i);
+  await expect(button).not.toHaveAttribute("aria-busy", "true");
   expect(consoleErrors).toEqual([]);
 });
 
 test("navegación móvil real y botones nativos conservan eventos de puntero", async ({ page }) => {
-  await page.goto(`${BASE}/academy/?qa=live-pointer-${Date.now()}`, {
-    waitUntil: "domcontentloaded",
-    timeout: 30000,
-  });
-  await expect.poll(async () => page.evaluate(() => window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__ === true), { timeout: 10000 }).toBe(true);
+  await openAcademy(page, "live-pointer");
 
   await page.evaluate(() => {
     document.querySelector("#login-view")?.setAttribute("hidden", "");

--- a/tests/owned-buttons.spec.mjs
+++ b/tests/owned-buttons.spec.mjs
@@ -49,16 +49,15 @@ async function installHarness(page) {
 
   await page.evaluate(() => {
     window.__openedCore = [];
-    window.__openedFallback = [];
+    window.__openedUnified = [];
     window.__nativeGridClicks = [];
     window.__nativeContinueClicks = [];
 
-    // academy-v39.js expone openCourse como función global en script clásico.
     window.openCourse = async (slug) => {
       window.__openedCore.push(slug);
     };
     window.KINECHECK_OPEN_PRODUCT = async (slug) => {
-      window.__openedFallback.push(slug);
+      window.__openedUnified.push(slug);
     };
 
     document.querySelector("#course-grid").addEventListener("click", (event) => {
@@ -73,7 +72,7 @@ async function installHarness(page) {
   await page.addScriptTag({ path: BRIDGE_SCRIPT });
 }
 
-test("tarjetas proxy usan el controlador nativo de Academy, no el opener alternativo", async ({ page }) => {
+test("tarjetas proxy usan el opener unificado y no duplican el flujo nativo", async ({ page }) => {
   await installHarness(page);
 
   await page.locator("#home-clinico").click();
@@ -81,13 +80,13 @@ test("tarjetas proxy usan el controlador nativo de Academy, no el opener alterna
   await page.locator("#recommended-pain").click();
   await page.locator("#home-recupera").click();
 
-  await expect.poll(async () => page.evaluate(() => window.__openedCore)).toEqual([
+  await expect.poll(async () => page.evaluate(() => window.__openedUnified)).toEqual([
     "kinecheck-clinico",
     "kinecheck-estudiante",
     "mas-alla-del-dolor",
     "kinecheck-recupera",
   ]);
-  await expect.poll(async () => page.evaluate(() => window.__openedFallback)).toEqual([]);
+  await expect.poll(async () => page.evaluate(() => window.__openedCore)).toEqual([]);
 });
 
 test("botones nativos de course-grid y Continuar no son interceptados por el bridge", async ({ page }) => {
@@ -105,10 +104,10 @@ test("botones nativos de course-grid y Continuar no son interceptados por el bri
     "evidencia-aplicada",
   ]);
   await expect.poll(async () => page.evaluate(() => window.__openedCore)).toEqual([]);
-  await expect.poll(async () => page.evaluate(() => window.__openedFallback)).toEqual([]);
+  await expect.poll(async () => page.evaluate(() => window.__openedUnified)).toEqual([]);
 });
 
-test("Continuar actividad usa el controlador nativo con el producto recordado", async ({ page }) => {
+test("Continuar actividad usa el opener unificado con el producto recordado", async ({ page }) => {
   await installHarness(page);
 
   await page.evaluate(() => {
@@ -116,10 +115,10 @@ test("Continuar actividad usa el controlador nativo con el producto recordado", 
   });
   await page.locator("#kc-home-continue").click();
 
-  await expect.poll(async () => page.evaluate(() => window.__openedCore)).toEqual([
+  await expect.poll(async () => page.evaluate(() => window.__openedUnified)).toEqual([
     "traumatologia-ortopedia-clinica",
   ]);
-  await expect.poll(async () => page.evaluate(() => window.__openedFallback)).toEqual([]);
+  await expect.poll(async () => page.evaluate(() => window.__openedCore)).toEqual([]);
 });
 
 test("Mis productos, Recursos, Cuenta y navegación móvil funcionan desde el controlador directo", async ({ page }) => {
@@ -156,7 +155,7 @@ test("Soporte responde aunque los listeners secundarios no carguen", async ({ pa
   await expect(page.locator("#support-launcher")).toHaveAttribute("aria-expanded", "true");
 });
 
-test("si el controlador nativo no existe, conserva el fallback del opener", async ({ page }) => {
+test("si el opener todavía no cargó, el bridge espera su disponibilidad", async ({ page }) => {
   await page.setContent(`
     <!doctype html><html><body>
       <div id="kc-toast" hidden></div>


### PR DESCRIPTION
Corrige el caso real reportado en móvil: las tarjetas de “Mis productos/Mis cursos” (`data-kc-open-owned`) dejan de usar una ruta distinta a las recomendaciones y pasan por `KINECHECK_OPEN_PRODUCT`, manteniendo intactos los botones nativos de Biblioteca/Continuar. Añade feedback visible de sesión mediante el opener existente, incorpora `data-kc-open-owned` a métricas y reemplaza la prueba que falseaba `openCourse()` por una prueba que ejecuta el opener real hasta una navegación interceptada en Chromium/WebKit. Cache-bust específico para bridge y métricas. No modifica Auth, Supabase, licencias, compras, webhooks, SSO backend, usuarios ni secretos.