### PR TITLE
Observe owned Academy clicks before bridge interception

### DIFF
--- a/academy/academy-brand-identity.js
+++ b/academy/academy-brand-identity.js
@@ -85,7 +85,7 @@
   loadScript("../assets/runtime-config.js", "data-kc-runtime", "20260807-1");
   loadScript("../assets/observability.js", "data-kc-observability", "20260807-1");
   loadScript("./security-hardening-v1.js", "data-kc-security-hardening", "20260807-1");
-  loadScript("../metrics-v1.js", "data-kc-launch-metrics", "20260809-ownedopener1");
+  loadScript("../metrics-v1.js", "data-kc-launch-metrics", "20260809-ownedobs1");
 
   // Orden deliberado: primero existe un único opener; luego el controlador de clicks.
   loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260809-directnav1");

--- a/metrics-v1.js
+++ b/metrics-v1.js
@@ -93,7 +93,9 @@
     if (path.startsWith("/platform/")) send("platform_login_view");
   }
 
-  document.addEventListener("click", (event) => {
+  // El bridge de Academy captura en window y puede detener propagación antes de document.
+  // Escuchar aquí garantiza que los toques de tarjetas proxy queden observables.
+  window.addEventListener("click", (event) => {
     const target = event.target instanceof Element ? event.target.closest("a,button") : null;
     if (!target) return;
 

--- a/tests/live-academy-runtime.spec.mjs
+++ b/tests/live-academy-runtime.spec.mjs
@@ -23,6 +23,24 @@ function collectUnexpectedConsoleErrors(page) {
   return consoleErrors;
 }
 
+async function captureMetrics(page) {
+  const events = [];
+  await page.route("**/functions/v1/metric-event", async (route) => {
+    try {
+      const payload = JSON.parse(route.request().postData() || "{}");
+      events.push(payload);
+    } catch {
+      // Un cuerpo no JSON no debe romper la prueba de navegación.
+    }
+    await route.fulfill({
+      status: 202,
+      contentType: "application/json; charset=utf-8",
+      body: '{"ok":true}',
+    });
+  });
+  return events;
+}
+
 async function openAcademy(page, label) {
   await page.goto(`${BASE}/academy/?qa=${label}-${Date.now()}`, {
     waitUntil: "domcontentloaded",
@@ -36,9 +54,12 @@ async function openAcademy(page, label) {
   })), { timeout: 10000 }).toEqual({ opener: "function", native: "function", bridge: true });
 }
 
-test("Mis productos usa el opener real y completa una navegación de curso", async ({ page }) => {
+test("Mis productos registra el toque, usa el opener real y completa una navegación de curso", async ({ page }) => {
   const consoleErrors = collectUnexpectedConsoleErrors(page);
+  const metricEvents = await captureMetrics(page);
   await openAcademy(page, "owned-real-open");
+
+  await expect.poll(() => metricEvents.some((event) => event.eventName === "page_view")).toBe(true);
 
   const runtime = await page.evaluate(() => ({
     scripts: [...document.scripts].map((script) => script.src).filter(Boolean),
@@ -93,6 +114,10 @@ test("Mis productos usa el opener real y completa una navegación de curso", asy
     ownedButton.click(),
   ]);
 
+  await expect.poll(() => metricEvents.some((event) => (
+    event.eventName === "course_open"
+    && event.productSlug === "comunicacion-clinica"
+  ))).toBe(true);
   await expect(page.locator("#qa-destination")).toHaveText("Destino QA");
   expect(consoleErrors).toEqual([]);
 });


### PR DESCRIPTION
Cierra el último agujero diagnóstico del caso móvil. El bridge de Academy intercepta clicks proxy en `window` con propagación detenida, por lo que métricas escuchando en `document` no veía `data-kc-open-owned`. Mueve solo la captura de métricas a `window`, fuerza una versión nueva del script y amplía el gate real para exigir `course_open` de Comunicación Clínica además de la navegación final. No modifica Auth, Supabase, licencias, compras, webhooks, SSO backend, usuarios ni secretos.