### PR TITLE
Add Chromium and WebKit coverage for app SSO relay

### DIFF
--- a/.github/workflows/validate-recommended-buttons.yml
+++ b/.github/workflows/validate-recommended-buttons.yml
@@ -12,11 +12,14 @@ on:
       - 'academy/academy-learning-path-v4.js'
       - 'academy/academy-kinecheck-v4.js'
       - 'academy/academy-v39.js'
+      - 'academy/app-sso-relay.html'
+      - 'academy/app-sso-relay.js'
       - 'academy/mi-kinecheck-v1.js'
       - 'academy/mi-kinecheck-simplify-v2.js'
       - 'tests/recommended-buttons.spec.mjs'
       - 'tests/owned-buttons.spec.mjs'
       - 'tests/live-academy-runtime.spec.mjs'
+      - 'tests/app-sso-relay.spec.mjs'
       - '.github/workflows/validate-recommended-buttons.yml'
   push:
     branches: [main]
@@ -29,11 +32,14 @@ on:
       - 'academy/academy-learning-path-v4.js'
       - 'academy/academy-kinecheck-v4.js'
       - 'academy/academy-v39.js'
+      - 'academy/app-sso-relay.html'
+      - 'academy/app-sso-relay.js'
       - 'academy/mi-kinecheck-v1.js'
       - 'academy/mi-kinecheck-simplify-v2.js'
       - 'tests/recommended-buttons.spec.mjs'
       - 'tests/owned-buttons.spec.mjs'
       - 'tests/live-academy-runtime.spec.mjs'
+      - 'tests/app-sso-relay.spec.mjs'
       - '.github/workflows/validate-recommended-buttons.yml'
 
 permissions:
@@ -77,21 +83,21 @@ jobs:
       - name: Test recommendation and owned product buttons
         run: npx playwright test tests/recommended-buttons.spec.mjs tests/owned-buttons.spec.mjs --reporter=line
 
-      - name: Test Academy runtime in Chromium
+      - name: Test Academy runtime and app relay in Chromium
         id: chromium_gate
         if: always()
         continue-on-error: true
         env:
           BASE_URL: ${{ github.event_name == 'pull_request' && 'http://127.0.0.1:4173' || 'https://kinecheck.cl' }}
-        run: npx playwright test tests/live-academy-runtime.spec.mjs --browser=chromium --reporter=line
+        run: npx playwright test tests/live-academy-runtime.spec.mjs tests/app-sso-relay.spec.mjs --browser=chromium --reporter=line
 
-      - name: Test Academy runtime in WebKit
+      - name: Test Academy runtime and app relay in WebKit
         id: webkit_gate
         if: always()
         continue-on-error: true
         env:
           BASE_URL: ${{ github.event_name == 'pull_request' && 'http://127.0.0.1:4173' || 'https://kinecheck.cl' }}
-        run: npx playwright test tests/live-academy-runtime.spec.mjs --browser=webkit --reporter=line
+        run: npx playwright test tests/live-academy-runtime.spec.mjs tests/app-sso-relay.spec.mjs --browser=webkit --reporter=line
 
       - name: Enforce Chromium and WebKit gates
         if: always()

--- a/tests/app-sso-relay.spec.mjs
+++ b/tests/app-sso-relay.spec.mjs
@@ -1,0 +1,73 @@
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.BASE_URL || "http://127.0.0.1:4173";
+const POST_URL = "https://kinecheck-clinico.emmanuelkine.chatgpt.site/api/license/sso";
+const HANDOFF_TYPE = "kinecheck-sso-v3-access-only";
+
+for (const product of ["kinecheck-estudiante", "kinecheck-recupera"]) {
+  test(`${product} conserva el handoff same-origin y envía el POST SSO`, async ({ page }) => {
+    let capturedPost = "";
+
+    await page.route(POST_URL, async (route) => {
+      capturedPost = route.request().postData() || "";
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: "<!doctype html><html><body><main id=relay-ok>SSO recibido</main></body></html>",
+      });
+    });
+
+    await page.goto(`${BASE}/academy/?qa=app-relay-source-${product}-${Date.now()}`, {
+      waitUntil: "domcontentloaded",
+      timeout: 30000,
+    });
+
+    const issuedAt = Date.now();
+    const expiresAt = Math.floor(issuedAt / 1000) + 3600;
+    const accessToken = `qa-${product}-access-token-abcdefghijklmnopqrstuvwxyz0123456789`;
+
+    await page.evaluate(({ type, issuedAtValue, expiresAtValue, token, productSlug }) => {
+      window.name = JSON.stringify({
+        type,
+        issuedAt: issuedAtValue,
+        product: productSlug,
+        access_token: token,
+        expires_at: expiresAtValue,
+        session: {
+          access_token: token,
+          expires_at: expiresAtValue,
+          token_type: "bearer",
+          handoff_access_only: true,
+        },
+      });
+    }, {
+      type: HANDOFF_TYPE,
+      issuedAtValue: issuedAt,
+      expiresAtValue: expiresAt,
+      token: accessToken,
+      productSlug: product,
+    });
+
+    const postRequest = page.waitForRequest(
+      (request) => request.url() === POST_URL && request.method() === "POST",
+      { timeout: 10000 },
+    );
+
+    await page.goto(`${BASE}/academy/app-sso-relay.html?qa=${product}-${Date.now()}`, {
+      waitUntil: "domcontentloaded",
+      timeout: 30000,
+    });
+
+    const request = await postRequest;
+    const body = new URLSearchParams(request.postData() || capturedPost);
+
+    expect(body.get("product")).toBe(product);
+    expect(body.get("access_token")).toBe(accessToken);
+    expect(body.get("expires_at")).toBe(String(expiresAt));
+    expect(body.get("issued_at")).toBe(String(issuedAt));
+    expect(body.get("handoff_type")).toBe(HANDOFF_TYPE);
+
+    await expect(page.locator("#relay-ok")).toHaveText("SSO recibido");
+    await expect.poll(async () => page.evaluate(() => window.name)).toBe("");
+  });
+}


### PR DESCRIPTION
Cierra la brecha de QA detectada en la revisión integral de Academy.

Añade una regresión de navegador para KineCheck Estudiante y KineCheck Recupera que comprueba, en Chromium y WebKit:
- persistencia del handoff `window.name` desde Academy al relay same-origin;
- consumo y limpieza de `window.name`;
- POST al endpoint SSO oficial;
- campos `product`, `access_token`, `expires_at`, `issued_at` y `handoff_type` correctos.

El test intercepta el endpoint SSO y no usa ni modifica licencias reales, usuarios, compras, Auth, Supabase, webhooks, secretos ni backend. No cambia lógica de producción; solo amplía los gates.