### PR TITLE
Accept canonical Recupera consent URL in browser gate

### DIFF
--- a/tests/app-sso-relay.spec.mjs
+++ b/tests/app-sso-relay.spec.mjs
@@ -64,7 +64,7 @@ for (const product of ["kinecheck-estudiante", "kinecheck-recupera"]) {
     });
 
     if (product === "kinecheck-recupera") {
-      await expect(page).toHaveURL(/\/recupera\/consentimiento\.html$/);
+      await expect(page).toHaveURL(/\/recupera\/consentimiento(?:\.html)?\/?$/);
       await page.locator("#recupera-consent").check();
       await page.getByRole("button", { name: "Aceptar y abrir KineCheck Recupera" }).click();
     }


### PR DESCRIPTION
Test-only correction. Production canonicalizes `/recupera/consentimiento.html` to `/recupera/consentimiento`. The prior post-merge failure was caused by an overly strict Playwright URL assertion. This PR accepts both canonical forms and does not modify product, consent, SSO, licenses, users or backend logic.