### PR TITLE
Corrige arquitectura pública y capa de confianza

### DIFF
--- a/.github/workflows/validate-launch-readiness-public.yml
+++ b/.github/workflows/validate-launch-readiness-public.yml
@@ -18,11 +18,13 @@ on:
       - "home.js"
       - "metrics-v1.js"
       - "productos/**"
+      - "muestras/**"
       - "academy/**"
       - "platform/**"
       - "tests/launch-readiness-public.spec.mjs"
       - "tests/public-source-regression.test.mjs"
       - "tests/product-overflow-diagnostic.mjs"
+      - "tests/public-trust-browser.spec.mjs"
       - ".github/workflows/validate-launch-readiness-public.yml"
   push:
     branches: [main]
@@ -41,11 +43,13 @@ on:
       - "home.js"
       - "metrics-v1.js"
       - "productos/**"
+      - "muestras/**"
       - "academy/**"
       - "platform/**"
       - "tests/launch-readiness-public.spec.mjs"
       - "tests/public-source-regression.test.mjs"
       - "tests/product-overflow-diagnostic.mjs"
+      - "tests/public-trust-browser.spec.mjs"
       - ".github/workflows/validate-launch-readiness-public.yml"
   workflow_dispatch:
 
@@ -71,7 +75,7 @@ jobs:
         run: |
           npm init -y >/dev/null 2>&1
           npm install playwright@1.55.0 >/dev/null 2>&1
-          npx playwright install --with-deps chromium >/dev/null 2>&1
+          npx playwright install --with-deps chromium webkit >/dev/null 2>&1
       - name: Validar PR contra el checkout exacto
         if: github.event_name == 'pull_request'
         run: |
@@ -82,6 +86,7 @@ jobs:
           BASE_URL=http://127.0.0.1:4173 node tests/product-overflow-diagnostic.mjs
           NO_JS=1 BASE_URL=http://127.0.0.1:4173 node tests/product-overflow-diagnostic.mjs
           BASE_URL=http://127.0.0.1:4173 node tests/launch-readiness-public.spec.mjs
+          BASE_URL=http://127.0.0.1:4173 node tests/public-trust-browser.spec.mjs
       - name: Diagnosticar overflow móvil de productos en producción
         if: github.event_name != 'pull_request'
         env:

--- a/_headers
+++ b/_headers
@@ -63,6 +63,10 @@
 /soporte/*
   Cache-Control: no-cache, must-revalidate
 
+/muestras/*
+  Cache-Control: public, max-age=3600, must-revalidate
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'
+
 /legal/*
   Cache-Control: public, max-age=3600, must-revalidate
 

--- a/academy/index.html
+++ b/academy/index.html
@@ -295,8 +295,8 @@
             <p>Aplicaciones, cursos y packs para profesionales, estudiantes, pacientes y universidades.</p>
           </div>
           <div class="kc-explore-categories">
-            <article><span>✚</span><strong>Aplicaciones</strong><p>Clínico, Estudiante y Recupera.</p></article>
-            <article><span>▤</span><strong>Cursos</strong><p>Formación clínica interactiva y aplicada.</p></article>
+            <article><span>✚</span><strong>Aplicaciones web</strong><p>Estudiante y Recupera · acceso desde navegador, sin instalación.</p></article>
+            <article><span>▤</span><strong>Formación</strong><p>KineCheck Clínico y cursos clínicos interactivos.</p></article>
             <article><span>◆</span><strong>Packs</strong><p>Combinaciones con acceso integrado.</p></article>
             <article><span>U</span><strong>Universidades</strong><p>Soluciones para docencia y práctica formativa.</p></article>
           </div>

--- a/docs/brand-architecture.md
+++ b/docs/brand-architecture.md
@@ -19,6 +19,8 @@ No usar **ECOSISTEMA CLÍNICO** como descriptor de toda la marca.
 - **KineCheck Estudiante**
 - **KineCheck Recupera**
 
+Ambas se comunican como **aplicaciones web**: se accede desde un navegador y no requieren instalación desde App Store o Google Play.
+
 ### KineCheck Formación
 
 - **KineCheck Clínico** — curso profesional avanzado de evaluación, seguridad y razonamiento musculoesquelético con **guía digital complementaria** incluida. El curso es el producto central; la guía apoya la aplicación y no reemplaza la ficha clínica institucional.
@@ -38,6 +40,9 @@ Los nombres propios de estos cursos no se cambian. La relación con la marca pue
 - Mantener **KineCheck** como marca raíz y no convertir las rutas técnicas en marcas visibles.
 - Mantener las asignaciones Apps, Formación y Packs indicadas en este documento.
 - No describir **KineCheck Clínico** como ficha clínica, registro kinésico institucional ni aplicación autónoma. Su definición comercial oficial es **curso profesional + guía digital complementaria**.
+- Reservar la familia **KineCheck Apps** exclusivamente para **KineCheck Estudiante** y **KineCheck Recupera**.
+- En superficies comerciales, indicar **“Aplicación web · sin instalación”** y no sugerir disponibilidad en App Store o Google Play.
+- Toda ficha comercial de KineCheck Clínico debe mostrar temario, autoría, metodología, una muestra pública y condiciones de soporte antes del checkout.
 - No abreviar ni renombrar productos o cursos en superficies comerciales, legales o de acceso.
 - Usar **SALUD MUSCULOESQUELÉTICA** cuando una superficie requiera el descriptor global.
 - La entrada pública canónica para usuarios con acceso es **`/academy/`**.

--- a/estudiantes/index.html
+++ b/estudiantes/index.html
@@ -1,1 +1,247 @@
-<!doctype html><html lang="es"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="description" content="Aprende progresivamente a estructurar la evaluación musculoesquelética y desarrollar razonamiento clínico con una guía paso a paso."><meta property="og:type" content="website"><meta property="og:locale" content="es_CL"><meta property="og:site_name" content="KineCheck"><meta property="og:title" content="KineCheck para estudiantes | Aprendizaje clínico progresivo"><meta property="og:description" content="Aprende progresivamente a estructurar la evaluación musculoesquelética y desarrollar razonamiento clínico con una guía paso a paso."><meta property="og:url" content="https://kinecheck.cl/estudiantes/"><link rel="canonical" href="https://kinecheck.cl/estudiantes/"><title>KineCheck para estudiantes</title><link rel="icon" href="../assets/kinecheck-mark.svg" type="image/svg+xml"><link rel="stylesheet" href="../kinecheck/site-v5.css?v=3"><script src="../kinecheck/site-v5.js?v=2" defer></script></head><body><a class="skip-link" href="#contenido">Saltar al contenido</a><header class="site-header"><a class="brand" href="../"><img src="../assets/kinecheck-mark.svg" alt="KineCheck"><div><strong>KineCheck</strong><small>ESTUDIANTES</small></div></a><button class="menu-button" data-menu-button aria-expanded="false" aria-label="Abrir menú" aria-controls="public-navigation">☰</button><nav id="public-navigation" data-public-nav aria-label="Navegación principal"><a href="#ruta">Ruta</a><a href="#productos">Productos</a><a href="#preguntas">Preguntas</a><a class="nav-button" href="../academy/">Ingresar</a></nav></header><main id="contenido"><section class="page-hero est"><span class="eyebrow" style="color:var(--blue)">PARA ESTUDIANTES</span><h1>Aprende a evaluar sin memorizar una lista de pruebas.</h1><p>KineCheck Estudiante te ayuda a conectar entrevista, examen físico, contexto y razonamiento clínico de forma progresiva.</p><div class="actions"><a class="primary" href="#productos">Ver opciones</a><a class="secondary" href="../academy/">Ya tengo acceso</a></div></section><section id="ruta" class="section alt"><div class="section-head"><span class="eyebrow" style="color:var(--blue)">RUTA SUGERIDA</span><h2>Una progresión para cada etapa.</h2></div><div class="feature-grid"><article class="feature"><h3>Inicio de carrera</h3><p>Lenguaje básico de evaluación, seguridad y organización de hallazgos.</p></article><article class="feature"><h3>Ciclo clínico</h3><p>Razonamiento, contexto biopsicosocial, pruebas y comunicación.</p></article><article class="feature"><h3>Internado y egreso</h3><p>Decisiones, documentación, presentación de casos y evidencia.</p></article></div></section><section id="productos" class="section"><div class="section-head"><span class="eyebrow" style="color:var(--blue)">OPCIONES PARA ESTUDIANTES</span><h2>Empieza simple o elige una ruta más completa.</h2></div><div class="product-grid"><article class="product featured"><span class="family-label">KINECHECK APPS</span><span class="tag">RECOMENDADO</span><h3>KineCheck Estudiante</h3><p>Flujo guiado para aprender evaluación y razonamiento clínico paso a paso.</p><div class="price"><small>Pago único</small><strong>$14.990 CLP</strong><span>Acceso por 12 meses</span></div><div class="actions"><a class="primary" href="https://pay.hotmart.com/G106801166S" target="_blank" rel="noopener noreferrer">Comprar</a></div></article><article class="product"><span class="family-label">KINECHECK PACKS</span><span class="tag">RUTA COMPLETA</span><h3>Pack KineCheck Estudiante</h3><p>Incluye KineCheck Estudiante y Más allá del Dolor.</p><div class="price"><small>Pago único</small><strong>$49.900 CLP</strong><span>Acceso por 12 meses</span></div><div class="actions"><a class="secondary" href="https://pay.hotmart.com/Q106891608M" target="_blank" rel="noopener noreferrer">Comprar pack</a></div></article><article class="product"><span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span><span class="tag">COMPLEMENTARIO</span><h3>Comunicación Clínica</h3><p>Escucha activa, empatía, validación y educación clínica.</p><div class="price"><small>Pago único</small><strong>$19.900 CLP</strong><span>Acceso por 12 meses</span></div><div class="actions"><a class="secondary" href="https://pay.hotmart.com/T106883983U" target="_blank" rel="noopener noreferrer">Comprar curso</a></div></article><article class="product"><span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span><span class="tag">COMPLEMENTARIO</span><h3>Evidencia Aplicada</h3><p>Busca, interpreta y usa evidencia con criterio.</p><div class="price"><small>Pago único</small><strong>$29.990 CLP</strong><span>Acceso por 12 meses</span></div><div class="actions"><a class="secondary" href="https://pay.hotmart.com/F106921972I" target="_blank" rel="noopener noreferrer">Comprar curso</a></div></article></div></section><section id="preguntas" class="section alt"><div class="section-head"><span class="eyebrow" style="color:var(--blue)">PREGUNTAS FRECUENTES</span><h2>Antes de comenzar.</h2></div><div class="faq"><details><summary>¿Necesito estar en internado?</summary><p>No. Está pensado para acompañar desde el aprendizaje inicial hasta la práctica clínica supervisada.</p></details><details><summary>¿Reemplaza la supervisión docente?</summary><p>No. Es un apoyo educativo.</p></details></div></section><section class="final-cta"><span class="eyebrow" style="color:var(--blue)">KINECHECK ESTUDIANTE</span><h2>Construye criterio clínico desde el inicio.</h2><div class="actions" style="justify-content:center"><a class="primary" href="https://pay.hotmart.com/G106801166S" target="_blank" rel="noopener noreferrer">Comprar KineCheck Estudiante</a><a class="secondary" href="../">Volver al inicio</a></div></section></main><footer><div class="brand"><img src="../assets/kinecheck-mark.svg" alt="KineCheck"><div><strong>KineCheck</strong><small>SALUD MUSCULOESQUELÉTICA</small></div></div><p>Soporte: <a href="mailto:soporte.kinecheck@gmail.com">soporte.kinecheck@gmail.com</a></p></footer></body></html>
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      name="description"
+      content="Aprende progresivamente a estructurar la evaluación musculoesquelética y desarrollar razonamiento clínico con una guía paso a paso."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_CL" />
+    <meta property="og:site_name" content="KineCheck" />
+    <meta
+      property="og:title"
+      content="KineCheck para estudiantes | Aprendizaje clínico progresivo"
+    />
+    <meta
+      property="og:description"
+      content="Aprende progresivamente a estructurar la evaluación musculoesquelética y desarrollar razonamiento clínico con una guía paso a paso."
+    />
+    <meta property="og:url" content="https://kinecheck.cl/estudiantes/" />
+    <link rel="canonical" href="https://kinecheck.cl/estudiantes/" />
+    <title>KineCheck para estudiantes</title>
+    <link rel="icon" href="../assets/kinecheck-mark.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="../kinecheck/site-v5.css?v=3" />
+    <script src="../kinecheck/site-v5.js?v=2" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#contenido">Saltar al contenido</a>
+    <header class="site-header">
+      <a class="brand" href="../"
+        ><img src="../assets/kinecheck-mark.svg" alt="KineCheck" />
+        <div><strong>KineCheck</strong><small>ESTUDIANTES</small></div></a
+      ><button
+        class="menu-button"
+        data-menu-button
+        aria-expanded="false"
+        aria-label="Abrir menú"
+        aria-controls="public-navigation"
+      >
+        ☰
+      </button>
+      <nav
+        id="public-navigation"
+        data-public-nav
+        aria-label="Navegación principal"
+      >
+        <a href="#ruta">Ruta</a><a href="#productos">Productos</a
+        ><a href="#preguntas">Preguntas</a
+        ><a class="nav-button" href="../academy/">Ingresar</a>
+      </nav>
+    </header>
+    <main id="contenido">
+      <section class="page-hero est">
+        <span class="family-label"
+          >KINECHECK APPS · APLICACIÓN WEB · SIN INSTALACIÓN</span
+        >
+        <span class="eyebrow" style="color: var(--blue)">PARA ESTUDIANTES</span>
+        <h1>Aprende a evaluar sin memorizar una lista de pruebas.</h1>
+        <p>
+          KineCheck Estudiante es una aplicación web que te ayuda a conectar
+          entrevista, examen físico, contexto y razonamiento clínico de forma
+          progresiva. Accede desde navegador, sin instalación.
+        </p>
+        <div class="actions">
+          <a class="primary" href="#productos">Ver opciones</a
+          ><a class="secondary" href="../muestras/#estudiante"
+            >Probar una muestra</a
+          ><a class="secondary" href="../academy/">Ya tengo acceso</a>
+        </div>
+      </section>
+      <section id="ruta" class="section alt">
+        <div class="section-head">
+          <span class="eyebrow" style="color: var(--blue)">RUTA SUGERIDA</span>
+          <h2>Una progresión para cada etapa.</h2>
+        </div>
+        <div class="feature-grid">
+          <article class="feature">
+            <h3>Inicio de carrera</h3>
+            <p>
+              Lenguaje básico de evaluación, seguridad y organización de
+              hallazgos.
+            </p>
+          </article>
+          <article class="feature">
+            <h3>Ciclo clínico</h3>
+            <p>
+              Razonamiento, contexto biopsicosocial, pruebas y comunicación.
+            </p>
+          </article>
+          <article class="feature">
+            <h3>Internado y egreso</h3>
+            <p>Decisiones, documentación, presentación de casos y evidencia.</p>
+          </article>
+        </div>
+      </section>
+      <section id="productos" class="section">
+        <div class="section-head">
+          <span class="eyebrow" style="color: var(--blue)"
+            >OPCIONES PARA ESTUDIANTES</span
+          >
+          <h2>Empieza simple o elige una ruta más completa.</h2>
+        </div>
+        <div class="product-grid">
+          <article class="product featured">
+            <span class="family-label">KINECHECK APPS · APLICACIÓN WEB</span
+            ><span class="tag">RECOMENDADO</span>
+            <h3>KineCheck Estudiante</h3>
+            <p>
+              Flujo guiado desde navegador para aprender evaluación y
+              razonamiento clínico paso a paso, sin instalación.
+            </p>
+            <div class="price">
+              <small>Pago único</small><strong>$14.990 CLP</strong
+              ><span>Acceso por 12 meses</span>
+            </div>
+            <div class="actions">
+              <a
+                class="primary"
+                href="https://pay.hotmart.com/G106801166S"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Comprar</a
+              ><a class="secondary" href="../muestras/#estudiante"
+                >Ver demostración</a
+              >
+            </div>
+          </article>
+          <article class="product">
+            <span class="family-label">KINECHECK PACKS</span
+            ><span class="tag">RUTA COMPLETA</span>
+            <h3>Pack KineCheck Estudiante</h3>
+            <p>Incluye KineCheck Estudiante y Más allá del Dolor.</p>
+            <div class="price">
+              <small>Pago único</small><strong>$49.900 CLP</strong
+              ><span>Acceso por 12 meses</span>
+            </div>
+            <div class="actions">
+              <a
+                class="secondary"
+                href="https://pay.hotmart.com/Q106891608M"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Comprar pack</a
+              >
+            </div>
+          </article>
+          <article class="product">
+            <span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span
+            ><span class="tag">COMPLEMENTARIO</span>
+            <h3>Comunicación Clínica</h3>
+            <p>Escucha activa, empatía, validación y educación clínica.</p>
+            <div class="price">
+              <small>Pago único</small><strong>$19.900 CLP</strong
+              ><span>Acceso por 12 meses</span>
+            </div>
+            <div class="actions">
+              <a
+                class="secondary"
+                href="https://pay.hotmart.com/T106883983U"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Comprar curso</a
+              >
+            </div>
+          </article>
+          <article class="product">
+            <span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span
+            ><span class="tag">COMPLEMENTARIO</span>
+            <h3>Evidencia Aplicada</h3>
+            <p>Busca, interpreta y usa evidencia con criterio.</p>
+            <div class="price">
+              <small>Pago único</small><strong>$29.990 CLP</strong
+              ><span>Acceso por 12 meses</span>
+            </div>
+            <div class="actions">
+              <a
+                class="secondary"
+                href="https://pay.hotmart.com/F106921972I"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Comprar curso</a
+              >
+            </div>
+          </article>
+        </div>
+      </section>
+      <section id="preguntas" class="section alt">
+        <div class="section-head">
+          <span class="eyebrow" style="color: var(--blue)"
+            >PREGUNTAS FRECUENTES</span
+          >
+          <h2>Antes de comenzar.</h2>
+        </div>
+        <div class="faq">
+          <details>
+            <summary>¿Necesito estar en internado?</summary>
+            <p>
+              No. Está pensado para acompañar desde el aprendizaje inicial hasta
+              la práctica clínica supervisada.
+            </p>
+          </details>
+          <details>
+            <summary>¿Reemplaza la supervisión docente?</summary>
+            <p>No. Es un apoyo educativo.</p>
+          </details>
+          <details>
+            <summary>¿Debo instalar una aplicación?</summary>
+            <p>
+              No. KineCheck Estudiante funciona desde un navegador moderno en
+              computador, tablet o teléfono.
+            </p>
+          </details>
+        </div>
+      </section>
+      <section class="final-cta">
+        <span class="eyebrow" style="color: var(--blue)"
+          >KINECHECK ESTUDIANTE</span
+        >
+        <h2>Construye criterio clínico desde el inicio.</h2>
+        <div class="actions" style="justify-content: center">
+          <a
+            class="primary"
+            href="https://pay.hotmart.com/G106801166S"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Comprar KineCheck Estudiante</a
+          ><a class="secondary" href="../">Volver al inicio</a>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="brand">
+        <img src="../assets/kinecheck-mark.svg" alt="KineCheck" />
+        <div>
+          <strong>KineCheck</strong><small>SALUD MUSCULOESQUELÉTICA</small>
+        </div>
+      </div>
+      <p>
+        Soporte:
+        <a href="mailto:soporte.kinecheck@gmail.com"
+          >soporte.kinecheck@gmail.com</a
+        >
+      </p>
+    </footer>
+  </body>
+</html>

--- a/home-core-20260806.js
+++ b/home-core-20260806.js
@@ -24,8 +24,8 @@
   });
   const PRODUCT_LABELS = Object.freeze({
     "kinecheck-clinico": "Curso profesional + guía complementaria · evaluación y razonamiento",
-    "kinecheck-estudiante": "Aplicación formativa · razonamiento guiado",
-    "kinecheck-recupera": "Aplicación para pacientes · progreso y ejercicios",
+    "kinecheck-estudiante": "Aplicación web · razonamiento guiado · sin instalación",
+    "kinecheck-recupera": "Aplicación web · progreso y ejercicios · sin instalación",
     "comunicacion-clinica": "Curso interactivo · comunicación en salud",
     "mas-alla-del-dolor": "Curso clínico · evaluación musculoesquelética",
     "evidencia-aplicada": "Curso clínico · evidencia y decisiones",

--- a/index.html
+++ b/index.html
@@ -1,1 +1,448 @@
-<!doctype html><html lang="es"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="description" content="KineCheck ayuda a profesionales, estudiantes y personas en recuperación musculoesquelética a aprender, decidir y hacer seguimiento con mayor claridad."><meta name="theme-color" content="#071d22"><meta name="robots" content="index,follow,max-image-preview:large"><meta property="og:type" content="website"><meta property="og:locale" content="es_CL"><meta property="og:site_name" content="KineCheck"><meta property="og:title" content="KineCheck | Aprende, decide y recupera con mayor claridad"><meta property="og:description" content="Formación, herramientas clínicas y seguimiento digital para profesionales, estudiantes y personas en recuperación."><meta property="og:url" content="https://kinecheck.cl/"><link rel="canonical" href="https://kinecheck.cl/"><title>KineCheck | Aprende, decide y recupera con mayor claridad</title><link rel="icon" href="./assets/kinecheck-mark.svg" type="image/svg+xml"><link rel="stylesheet" href="./kinecheck/site-v5.css?v=6"><script src="./kinecheck/site-v5.js?v=3" defer></script></head><body><a class="skip-link" href="#contenido">Saltar al contenido</a><header class="site-header"><a class="brand" href="./" aria-label="KineCheck inicio"><img src="./assets/kinecheck-mark.svg" alt="KineCheck"><div><strong>KineCheck</strong><small>SALUD MUSCULOESQUELÉTICA</small></div></a><button class="menu-button" data-menu-button aria-expanded="false" aria-label="Abrir menú" aria-controls="public-navigation">☰</button><nav id="public-navigation" data-public-nav aria-label="Navegación principal"><a href="#elige">Para quién</a><a href="#productos">Productos</a><a href="#como-funciona">Cómo funciona</a><a class="nav-button" href="./academy/">Ingresar</a></nav></header><main id="contenido"><section class="hero"><div><span class="eyebrow">REHABILITACIÓN MUSCULOESQUELÉTICA CON SENTIDO</span><h1>Aprende mejor. Decide con mayor seguridad. <em>Acompaña mejor la recuperación.</em></h1><p>KineCheck reúne formación, herramientas educativas y seguimiento digital para profesionales, estudiantes y personas en recuperación.</p><div class="actions"><a class="primary" href="#elige">Elegir mi experiencia</a><a class="text-link" href="./academy/">Ya tengo acceso →</a></div><div class="trust-row"><div><span aria-hidden="true">✓</span><b>Basado en evidencia</b></div><div><span aria-hidden="true">✓</span><b>Aplicación práctica</b></div><div><span aria-hidden="true">✓</span><b>Precios visibles</b></div><div><span aria-hidden="true">✓</span><b>Compra segura</b></div></div></div><aside class="hero-card"><span class="eyebrow">UNA PLATAFORMA, TRES EXPERIENCIAS</span><h2>Empieza por quién eres.</h2><p>Selecciona tu perfil y conoce las soluciones pertinentes para tu etapa.</p><div class="mini-grid"><a href="./profesionales/"><strong>PRO</strong><span>Formación clínica</span></a><a href="./estudiantes/"><strong>EST</strong><span>Aprendizaje guiado</span></a><a href="./recupera/"><strong>REC</strong><span>Seguimiento simple</span></a><a href="#productos"><strong>CLP</strong><span>Precios antes de comprar</span></a></div></aside></section><section id="elige" class="section alt"><div class="section-head"><span class="eyebrow">ELIGE TU EXPERIENCIA</span><h2>¿Quién eres?</h2><p>Una sola decisión te lleva a la experiencia y los productos más pertinentes para ti.</p></div><div class="audience-grid"><a class="audience-card pro" href="./profesionales/"><span class="icon" aria-hidden="true">👨‍⚕️</span><h3>Soy profesional</h3><p>Fortalece evaluación, seguridad y razonamiento clínico con formación aplicada.</p><b>Ver experiencia profesional →</b></a><a class="audience-card est" href="./estudiantes/"><span class="icon" aria-hidden="true">🎓</span><h3>Soy estudiante</h3><p>Aprende evaluación musculoesquelética paso a paso y construye criterio clínico.</p><b>Ver experiencia estudiante →</b></a><a class="audience-card rec" href="./recupera/"><span class="icon" aria-hidden="true">❤️</span><h3>Estoy en recuperación</h3><p>Registra cómo te has sentido, sigue tu plan y observa tu progreso sin tecnicismos.</p><b>Ver KineCheck Recupera →</b></a></div></section><section id="productos" class="section"><div class="section-head"><span class="eyebrow">PRODUCTOS PRINCIPALES</span><h2>Conoce el precio antes de decidir.</h2><p>Cada producto muestra su valor, vigencia y propósito antes de enviarte al checkout oficial de Hotmart.</p></div><div class="brand-family-grid" aria-label="Familias de productos KineCheck"><article class="brand-family-card"><span>KINECHECK APPS</span><strong>Aplicaciones para aprender y acompañar</strong><p>KineCheck Estudiante · KineCheck Recupera</p></article><article class="brand-family-card"><span>KINECHECK FORMACIÓN</span><strong>Cursos por KineCheck</strong><p>KineCheck Clínico · Comunicación Clínica · Más allá del Dolor · Evidencia Aplicada · Traumatología y Ortopedia Clínica</p></article><article class="brand-family-card"><span>KINECHECK PACKS</span><strong>Rutas combinadas</strong><p>Pack KineCheck Estudiante</p></article></div><div class="product-grid product-showcase"><article class="product featured"><span class="family-label">KINECHECK FORMACIÓN + GUÍA COMPLEMENTARIA</span><div class="product-preview clinical" aria-label="Vista representativa de KineCheck Clínico"><div class="preview-top"><span>KC</span><i></i><i></i></div><div class="preview-body"><b>Evaluación segura</b><span>Banderas clínicas</span><span>Hipótesis y decisiones</span><span>Guía complementaria</span></div></div><span class="tag">PROFESIONALES · 12 MESES</span><h3>KineCheck Clínico</h3><p>Curso profesional avanzado de evaluación, seguridad y razonamiento musculoesquelético con guía digital complementaria.</p><div class="price"><small>Pago único</small><strong>$39.990 CLP</strong><span>Acceso por 12 meses</span></div><div class="product-actions"><a class="primary" href="https://pay.hotmart.com/L106791841D" target="_blank" rel="noopener noreferrer">Comprar ahora</a><a class="access-link" href="./academy/">Ya tengo acceso</a><a class="access-link" href="./productos/kinecheck-clinico/">Ver ficha del producto</a></div></article><article class="product"><span class="family-label">KINECHECK APPS</span><div class="product-preview student" aria-label="Vista representativa de KineCheck Estudiante"><div class="preview-top"><span>KE</span><i></i><i></i></div><div class="preview-body"><b>Próximo paso</b><span>Entrevista clínica</span><span>Práctica guiada</span><span>Retroalimentación</span></div></div><span class="tag">ESTUDIANTES · 12 MESES</span><h3>KineCheck Estudiante</h3><p>Aplicación guiada para aprender evaluación y razonamiento clínico paso a paso.</p><div class="price"><small>Pago único</small><strong>$14.990 CLP</strong><span>Acceso por 12 meses</span></div><div class="product-actions"><a class="primary" href="https://pay.hotmart.com/G106801166S" target="_blank" rel="noopener noreferrer">Comprar ahora</a><a class="access-link" href="./academy/">Ya tengo acceso</a><a class="access-link" href="./productos/kinecheck-estudiante/">Ver ficha del producto</a></div></article><article class="product"><span class="family-label">KINECHECK APPS</span><div class="product-preview recovery" aria-label="Vista representativa de KineCheck Recupera"><div class="preview-top"><span>KR</span><i></i><i></i></div><div class="preview-body"><b>¿Cómo estás hoy?</b><span>Mis ejercicios</span><span>Mi progreso</span><span>Preguntas para mi kinesiólogo</span></div></div><span class="tag">RECUPERACIÓN · 3 MESES</span><h3>KineCheck Recupera</h3><p>Seguimiento simple de síntomas, función, ejercicios y progreso durante tu recuperación.</p><div class="price"><small>Pago único</small><strong>$9.990 CLP</strong><span>Acceso por 3 meses</span></div><div class="product-actions"><a class="primary" href="https://pay.hotmart.com/P106806251E" target="_blank" rel="noopener noreferrer">Comprar ahora</a><a class="access-link" href="./academy/">Ya tengo acceso</a><a class="access-link" href="./productos/kinecheck-recupera/">Ver ficha del producto</a></div></article></div><p class="catalog-note">KineCheck Formación, KineCheck Apps y KineCheck Packs se combinan según la etapa y necesidad de cada persona.</p></section><section id="como-funciona" class="section alt"><div class="section-head"><span class="eyebrow">RECORRIDO SIMPLE</span><h2>Entiende, elige y accede.</h2></div><div class="steps"><article class="step"><strong>1</strong><h3>Selecciona tu perfil</h3><p>Accede a información y productos pertinentes para tu etapa.</p></article><article class="step"><strong>2</strong><h3>Revisa qué incluye</h3><p>Conoce el propósito, el precio y la vigencia antes de comprar.</p></article><article class="step"><strong>3</strong><h3>Compra e ingresa</h3><p>Paga en Hotmart e inicia sesión con el mismo correo utilizado en la compra.</p></article></div></section><section class="final-cta"><span class="eyebrow">KINECHECK</span><h2>Encuentra la experiencia que realmente necesitas.</h2><div class="actions" style="justify-content:center"><a class="primary" href="#elige">Elegir mi perfil</a><a class="text-link" href="./academy/">Ingresar a mi cuenta →</a></div></section></main><footer><div><a class="brand" href="./"><img src="./assets/kinecheck-mark.svg" alt="KineCheck"><div><strong>KineCheck</strong><small>SALUD MUSCULOESQUELÉTICA</small></div></a><p class="legal">Formación y herramientas digitales para rehabilitación musculoesquelética.</p></div><div><p>Soporte: <a href="mailto:soporte.kinecheck@gmail.com" data-support-email aria-label="Correo de soporte KineCheck">soporte.kinecheck@gmail.com</a></p><small>© 2026 KineCheck</small></div></footer></body></html>
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      name="description"
+      content="KineCheck ayuda a profesionales, estudiantes y personas en recuperación musculoesquelética a aprender, decidir y hacer seguimiento con mayor claridad."
+    />
+    <meta name="theme-color" content="#071d22" />
+    <meta name="robots" content="index,follow,max-image-preview:large" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_CL" />
+    <meta property="og:site_name" content="KineCheck" />
+    <meta
+      property="og:title"
+      content="KineCheck | Aprende, decide y recupera con mayor claridad"
+    />
+    <meta
+      property="og:description"
+      content="Formación, herramientas clínicas y seguimiento digital para profesionales, estudiantes y personas en recuperación."
+    />
+    <meta property="og:url" content="https://kinecheck.cl/" />
+    <link rel="canonical" href="https://kinecheck.cl/" />
+    <title>KineCheck | Aprende, decide y recupera con mayor claridad</title>
+    <link rel="icon" href="./assets/kinecheck-mark.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="./kinecheck/site-v5.css?v=6" />
+    <link
+      rel="stylesheet"
+      href="./kinecheck/public-trust-v1.css?v=20260809-1"
+    />
+    <script src="./kinecheck/site-v5.js?v=3" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#contenido">Saltar al contenido</a>
+    <header class="site-header">
+      <a class="brand" href="./" aria-label="KineCheck inicio"
+        ><img src="./assets/kinecheck-mark.svg" alt="KineCheck" />
+        <div>
+          <strong>KineCheck</strong><small>SALUD MUSCULOESQUELÉTICA</small>
+        </div></a
+      ><button
+        class="menu-button"
+        data-menu-button
+        aria-expanded="false"
+        aria-label="Abrir menú"
+        aria-controls="public-navigation"
+      >
+        ☰
+      </button>
+      <nav
+        id="public-navigation"
+        data-public-nav
+        aria-label="Navegación principal"
+      >
+        <a href="#elige">Para quién</a><a href="#productos">Productos</a
+        ><a href="#confianza">Confianza</a
+        ><a href="#como-funciona">Cómo funciona</a
+        ><a class="nav-button" href="./academy/">Ingresar</a>
+      </nav>
+    </header>
+    <main id="contenido">
+      <section class="hero">
+        <div>
+          <span class="eyebrow"
+            >REHABILITACIÓN MUSCULOESQUELÉTICA CON SENTIDO</span
+          >
+          <h1>
+            Aprende mejor. Decide con mayor seguridad.
+            <em>Acompaña mejor la recuperación.</em>
+          </h1>
+          <p>
+            KineCheck reúne formación, herramientas educativas y seguimiento
+            digital para profesionales, estudiantes y personas en recuperación.
+          </p>
+          <div class="actions">
+            <a class="primary" href="#elige">Elegir mi experiencia</a
+            ><a class="text-link" href="./academy/">Ya tengo acceso →</a>
+          </div>
+          <div class="trust-row">
+            <div>
+              <span aria-hidden="true">✓</span><b>Basado en evidencia</b>
+            </div>
+            <div>
+              <span aria-hidden="true">✓</span><b>Aplicación práctica</b>
+            </div>
+            <div><span aria-hidden="true">✓</span><b>Precios visibles</b></div>
+            <div><span aria-hidden="true">✓</span><b>Compra segura</b></div>
+          </div>
+        </div>
+        <aside class="hero-card">
+          <span class="eyebrow">UNA PLATAFORMA, TRES EXPERIENCIAS</span>
+          <h2>Empieza por quién eres.</h2>
+          <p>
+            Selecciona tu perfil y conoce las soluciones pertinentes para tu
+            etapa.
+          </p>
+          <div class="mini-grid">
+            <a href="./profesionales/"
+              ><strong>PRO</strong><span>Formación clínica</span></a
+            ><a href="./estudiantes/"
+              ><strong>EST</strong><span>Aprendizaje guiado</span></a
+            ><a href="./recupera/"
+              ><strong>REC</strong><span>Seguimiento simple</span></a
+            ><a href="#productos"
+              ><strong>CLP</strong><span>Precios antes de comprar</span></a
+            >
+          </div>
+        </aside>
+      </section>
+      <section id="elige" class="section alt">
+        <div class="section-head">
+          <span class="eyebrow">ELIGE TU EXPERIENCIA</span>
+          <h2>¿Quién eres?</h2>
+          <p>
+            Una sola decisión te lleva a la experiencia y los productos más
+            pertinentes para ti.
+          </p>
+        </div>
+        <div class="audience-grid">
+          <a class="audience-card pro" href="./profesionales/"
+            ><span class="icon" aria-hidden="true">👨‍⚕️</span>
+            <h3>Soy profesional</h3>
+            <p>
+              Fortalece evaluación, seguridad y razonamiento clínico con
+              formación aplicada.
+            </p>
+            <b>Ver experiencia profesional →</b></a
+          ><a class="audience-card est" href="./estudiantes/"
+            ><span class="icon" aria-hidden="true">🎓</span>
+            <h3>Soy estudiante</h3>
+            <p>
+              Aprende evaluación musculoesquelética paso a paso y construye
+              criterio clínico.
+            </p>
+            <b>Ver experiencia estudiante →</b></a
+          ><a class="audience-card rec" href="./recupera/"
+            ><span class="icon" aria-hidden="true">❤️</span>
+            <h3>Estoy en recuperación</h3>
+            <p>
+              Registra cómo te has sentido, sigue tu plan y observa tu progreso
+              sin tecnicismos.
+            </p>
+            <b>Ver KineCheck Recupera →</b></a
+          >
+        </div>
+      </section>
+      <section id="productos" class="section">
+        <div class="section-head">
+          <span class="eyebrow">PRODUCTOS PRINCIPALES</span>
+          <h2>Conoce el precio antes de decidir.</h2>
+          <p>
+            Cada producto muestra su valor, vigencia y propósito antes de
+            enviarte al checkout oficial de Hotmart.
+          </p>
+        </div>
+        <div
+          class="brand-family-grid"
+          aria-label="Familias de productos KineCheck"
+        >
+          <article class="brand-family-card">
+            <span>KINECHECK APPS</span
+            ><strong>Aplicaciones web para aprender y acompañar</strong>
+            <p>KineCheck Estudiante · KineCheck Recupera · sin instalación</p>
+          </article>
+          <article class="brand-family-card">
+            <span>KINECHECK FORMACIÓN</span
+            ><strong>Cursos por KineCheck</strong>
+            <p>
+              KineCheck Clínico · Comunicación Clínica · Más allá del Dolor ·
+              Evidencia Aplicada · Traumatología y Ortopedia Clínica
+            </p>
+          </article>
+          <article class="brand-family-card">
+            <span>KINECHECK PACKS</span><strong>Rutas combinadas</strong>
+            <p>Pack KineCheck Estudiante</p>
+          </article>
+        </div>
+        <div class="product-grid product-showcase">
+          <article class="product featured">
+            <span class="family-label"
+              >KINECHECK FORMACIÓN + GUÍA COMPLEMENTARIA</span
+            >
+            <div
+              class="product-preview clinical"
+              aria-label="Vista representativa de KineCheck Clínico"
+            >
+              <div class="preview-top"><span>KC</span><i></i><i></i></div>
+              <div class="preview-body">
+                <b>Evaluación segura</b><span>Banderas clínicas</span
+                ><span>Hipótesis y decisiones</span
+                ><span>Guía complementaria</span>
+              </div>
+            </div>
+            <span class="tag">PROFESIONALES · 12 MESES</span>
+            <h3>KineCheck Clínico</h3>
+            <p>
+              Curso profesional avanzado de evaluación, seguridad y razonamiento
+              musculoesquelético con guía digital complementaria.
+            </p>
+            <div class="price">
+              <small>Pago único</small><strong>$39.990 CLP</strong
+              ><span>Acceso por 12 meses</span>
+            </div>
+            <div class="product-actions">
+              <a
+                class="primary"
+                href="https://pay.hotmart.com/L106791841D"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Comprar ahora</a
+              ><a class="access-link" href="./academy/">Ya tengo acceso</a
+              ><a class="access-link" href="./productos/kinecheck-clinico/"
+                >Ver ficha del producto</a
+              ><a class="access-link" href="./muestras/#clinico"
+                >Ver muestra funcional</a
+              >
+            </div>
+          </article>
+          <article class="product">
+            <span class="family-label">KINECHECK APPS · APLICACIÓN WEB</span>
+            <div
+              class="product-preview student"
+              aria-label="Vista representativa de KineCheck Estudiante"
+            >
+              <div class="preview-top"><span>KE</span><i></i><i></i></div>
+              <div class="preview-body">
+                <b>Próximo paso</b><span>Entrevista clínica</span
+                ><span>Práctica guiada</span><span>Retroalimentación</span>
+              </div>
+            </div>
+            <span class="tag">ESTUDIANTES · 12 MESES</span>
+            <h3>KineCheck Estudiante</h3>
+            <p>
+              Aplicación web guiada para aprender evaluación y razonamiento
+              clínico paso a paso. Accede desde navegador, sin instalación.
+            </p>
+            <div class="price">
+              <small>Pago único</small><strong>$14.990 CLP</strong
+              ><span>Acceso por 12 meses</span>
+            </div>
+            <div class="product-actions">
+              <a
+                class="primary"
+                href="https://pay.hotmart.com/G106801166S"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Comprar ahora</a
+              ><a class="access-link" href="./academy/">Ya tengo acceso</a
+              ><a class="access-link" href="./productos/kinecheck-estudiante/"
+                >Ver ficha del producto</a
+              ><a class="access-link" href="./muestras/#estudiante"
+                >Ver muestra funcional</a
+              >
+            </div>
+          </article>
+          <article class="product">
+            <span class="family-label">KINECHECK APPS · APLICACIÓN WEB</span>
+            <div
+              class="product-preview recovery"
+              aria-label="Vista representativa de KineCheck Recupera"
+            >
+              <div class="preview-top"><span>KR</span><i></i><i></i></div>
+              <div class="preview-body">
+                <b>¿Cómo estás hoy?</b><span>Mis ejercicios</span
+                ><span>Mi progreso</span
+                ><span>Preguntas para mi kinesiólogo</span>
+              </div>
+            </div>
+            <span class="tag">RECUPERACIÓN · 3 MESES</span>
+            <h3>KineCheck Recupera</h3>
+            <p>
+              Aplicación web de seguimiento de síntomas, función, ejercicios y
+              progreso. Accede desde navegador, sin instalación.
+            </p>
+            <div class="price">
+              <small>Pago único</small><strong>$9.990 CLP</strong
+              ><span>Acceso por 3 meses</span>
+            </div>
+            <div class="product-actions">
+              <a
+                class="primary"
+                href="https://pay.hotmart.com/P106806251E"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Comprar ahora</a
+              ><a class="access-link" href="./academy/">Ya tengo acceso</a
+              ><a class="access-link" href="./productos/kinecheck-recupera/"
+                >Ver ficha del producto</a
+              ><a class="access-link" href="./muestras/#recupera"
+                >Ver muestra funcional</a
+              >
+            </div>
+          </article>
+        </div>
+        <p class="catalog-note">
+          KineCheck Formación, KineCheck Apps y KineCheck Packs se combinan
+          según la etapa y necesidad de cada persona.
+        </p>
+        <div class="demo-callout">
+          <div>
+            <span class="eyebrow">MIRA ANTES DE COMPRAR</span>
+            <strong>Explora una muestra funcional de cada experiencia.</strong>
+            <p>
+              Conoce el enfoque de Clínico y prueba flujos representativos de
+              Estudiante y Recupera sin crear una cuenta ni guardar datos.
+            </p>
+          </div>
+          <a class="secondary" href="./muestras/">Abrir demostraciones</a>
+        </div>
+      </section>
+      <section
+        id="confianza"
+        class="section alt"
+        aria-labelledby="confianza-title"
+      >
+        <div class="section-head">
+          <span class="eyebrow">AUTORÍA, MÉTODO Y SOPORTE</span>
+          <h2 id="confianza-title">
+            Sabes quién lo desarrolla y cómo se construye.
+          </h2>
+          <p>
+            KineCheck hace visible la autoría, el criterio metodológico y el
+            acompañamiento disponible antes y después de la compra.
+          </p>
+        </div>
+        <div class="trust-layer-grid">
+          <article class="creator-card">
+            <div class="creator-mark" aria-hidden="true">EZ</div>
+            <div>
+              <span class="trust-kicker">DESARROLLADO POR</span>
+              <h3>Emmanuel Zúñiga</h3>
+              <p class="creator-role">
+                Kinesiólogo · Magíster en Docencia para la Educación Superior ·
+                Docente universitario
+              </p>
+              <p>
+                Experiencia clínica musculoesquelética y diseño de formación
+                aplicada para profesionales y estudiantes de kinesiología.
+              </p>
+            </div>
+          </article>
+          <div class="trust-detail-grid">
+            <article>
+              <span>01</span><strong>Metodología explícita</strong>
+              <p>
+                Objetivos por módulo, casos simulados, preguntas de decisión,
+                retroalimentación y práctica de recuperación.
+              </p>
+            </article>
+            <article>
+              <span>02</span><strong>Base científica trazable</strong>
+              <p>
+                Guías clínicas, marcos internacionales y revisiones se integran
+                con referencias visibles dentro de la formación.
+              </p>
+            </article>
+            <article>
+              <span>03</span><strong>Soporte postventa</strong>
+              <p>
+                Ayuda para acceso, licencia y funcionamiento. Objetivo de
+                respuesta inicial: dentro de 2 días hábiles.
+              </p>
+            </article>
+            <article>
+              <span>04</span><strong>Mejoras durante la vigencia</strong>
+              <p>
+                Las correcciones y mejoras del producto quedan disponibles
+                mientras el acceso se mantiene activo.
+              </p>
+            </article>
+          </div>
+        </div>
+        <div class="trust-actions">
+          <a class="primary" href="./productos/?producto=kinecheck-clinico"
+            >Revisar temario de Clínico</a
+          >
+          <a class="secondary" href="./muestras/">Ver demostraciones</a>
+          <a class="text-link" href="./soporte/"
+            >Conocer el soporte y postventa →</a
+          >
+        </div>
+      </section>
+      <section id="como-funciona" class="section alt">
+        <div class="section-head">
+          <span class="eyebrow">RECORRIDO SIMPLE</span>
+          <h2>Entiende, elige y accede.</h2>
+        </div>
+        <div class="steps">
+          <article class="step">
+            <strong>1</strong>
+            <h3>Selecciona tu perfil</h3>
+            <p>Accede a información y productos pertinentes para tu etapa.</p>
+          </article>
+          <article class="step">
+            <strong>2</strong>
+            <h3>Revisa qué incluye</h3>
+            <p>
+              Conoce el propósito, el precio y la vigencia antes de comprar.
+            </p>
+          </article>
+          <article class="step">
+            <strong>3</strong>
+            <h3>Compra e ingresa</h3>
+            <p>
+              Paga en Hotmart e inicia sesión con el mismo correo utilizado en
+              la compra.
+            </p>
+          </article>
+        </div>
+      </section>
+      <section class="final-cta">
+        <span class="eyebrow">KINECHECK</span>
+        <h2>Encuentra la experiencia que realmente necesitas.</h2>
+        <div class="actions" style="justify-content: center">
+          <a class="primary" href="#elige">Elegir mi perfil</a
+          ><a class="text-link" href="./academy/">Ingresar a mi cuenta →</a>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div>
+        <a class="brand" href="./"
+          ><img src="./assets/kinecheck-mark.svg" alt="KineCheck" />
+          <div>
+            <strong>KineCheck</strong><small>SALUD MUSCULOESQUELÉTICA</small>
+          </div></a
+        >
+        <p class="legal">
+          Formación y herramientas digitales para rehabilitación
+          musculoesquelética.
+        </p>
+      </div>
+      <div>
+        <p>
+          Soporte:
+          <a
+            href="mailto:soporte.kinecheck@gmail.com"
+            data-support-email
+            aria-label="Correo de soporte KineCheck"
+            >soporte.kinecheck@gmail.com</a
+          >
+        </p>
+        <small>© 2026 KineCheck</small>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/kinecheck/public-trust-v1.css
+++ b/kinecheck/public-trust-v1.css
@@ -1,0 +1,156 @@
+.demo-callout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1.5rem;
+  align-items: center;
+  margin-top: 2rem;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  border: 1px solid rgba(112, 183, 255, 0.3);
+  border-radius: 1.35rem;
+  background:
+    radial-gradient(
+      circle at 92% 5%,
+      rgba(112, 183, 255, 0.18),
+      transparent 34%
+    ),
+    rgba(255, 255, 255, 0.035);
+}
+
+.demo-callout strong {
+  display: block;
+  margin-top: 0.45rem;
+  font-size: clamp(1.25rem, 2vw, 1.7rem);
+}
+
+.demo-callout p {
+  max-width: 72ch;
+  margin: 0.45rem 0 0;
+  color: var(--muted);
+}
+
+.demo-callout .secondary {
+  white-space: nowrap;
+}
+
+.trust-layer-grid {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.82fr) minmax(0, 1.18fr);
+  gap: 1rem;
+}
+
+.creator-card,
+.trust-detail-grid article {
+  border: 1px solid var(--line);
+  border-radius: 1.35rem;
+  background: linear-gradient(
+    150deg,
+    rgba(255, 255, 255, 0.065),
+    rgba(255, 255, 255, 0.018)
+  );
+}
+
+.creator-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.15rem;
+  align-content: start;
+  padding: clamp(1.35rem, 3vw, 2rem);
+  box-shadow: var(--shadow);
+}
+
+.creator-mark {
+  display: grid;
+  place-items: center;
+  width: 64px;
+  height: 64px;
+  border-radius: 1.15rem;
+  background: linear-gradient(140deg, var(--green), #70b7ff);
+  color: #05241b;
+  font-size: 1.15rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+}
+
+.trust-kicker {
+  color: var(--green);
+  font-size: 0.68rem;
+  font-weight: 900;
+  letter-spacing: 0.15em;
+}
+
+.creator-card h3 {
+  margin: 0.3rem 0 0.5rem;
+  font-size: clamp(1.7rem, 3vw, 2.4rem);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+.creator-card p,
+.trust-detail-grid p {
+  margin: 0.55rem 0 0;
+  color: var(--muted);
+}
+
+.creator-card .creator-role {
+  color: #eefafa;
+  font-weight: 750;
+}
+
+.trust-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.trust-detail-grid article {
+  padding: 1.25rem;
+}
+
+.trust-detail-grid article > span {
+  display: inline-grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  margin-bottom: 0.9rem;
+  border-radius: 0.7rem;
+  background: rgba(85, 214, 165, 0.12);
+  color: var(--green);
+  font-size: 0.75rem;
+  font-weight: 950;
+}
+
+.trust-detail-grid strong {
+  display: block;
+  font-size: 1.05rem;
+}
+
+.trust-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-top: 1.25rem;
+}
+
+@media (max-width: 900px) {
+  .trust-layer-grid,
+  .demo-callout {
+    grid-template-columns: 1fr;
+  }
+
+  .demo-callout .secondary {
+    width: fit-content;
+  }
+}
+
+@media (max-width: 620px) {
+  .creator-card,
+  .trust-detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .demo-callout .secondary,
+  .trust-actions > a {
+    width: 100%;
+  }
+}

--- a/muestras/demo-v1.css
+++ b/muestras/demo-v1.css
@@ -1,0 +1,706 @@
+:root {
+  --demo-blue: #70b7ff;
+  --demo-gold: #ffc96b;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.demo-header nav {
+  flex-wrap: wrap;
+}
+
+main {
+  overflow: hidden;
+}
+
+.demo-hero {
+  min-height: 78vh;
+  padding: clamp(4.5rem, 10vw, 8.5rem) clamp(1rem, 7vw, 7rem);
+  background:
+    radial-gradient(
+      circle at 78% 18%,
+      rgba(112, 183, 255, 0.18),
+      transparent 30rem
+    ),
+    radial-gradient(
+      circle at 14% 80%,
+      rgba(85, 214, 165, 0.13),
+      transparent 28rem
+    );
+}
+
+.demo-hero h1 {
+  max-width: 14ch;
+  margin: 0.7rem 0 1.2rem;
+  font-size: clamp(3rem, 7.5vw, 7.2rem);
+  line-height: 0.94;
+  letter-spacing: -0.06em;
+}
+
+.demo-hero > p {
+  max-width: 70ch;
+  color: var(--muted);
+  font-size: clamp(1.05rem, 2vw, 1.3rem);
+}
+
+.demo-assurances {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 1.5rem;
+}
+
+.demo-assurances span,
+.browser-badge {
+  padding: 0.55rem 0.75rem;
+  border: 1px solid rgba(85, 214, 165, 0.34);
+  border-radius: 999px;
+  background: rgba(85, 214, 165, 0.075);
+  color: #dff9ee;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.07em;
+}
+
+.demo-section,
+.evidence-section {
+  padding: clamp(4.5rem, 9vw, 8rem) clamp(1rem, 6vw, 6rem);
+  scroll-margin-top: 84px;
+}
+
+.demo-section {
+  border-top: 1px solid var(--line);
+}
+.student-demo {
+  background: rgba(112, 183, 255, 0.035);
+}
+.recovery-demo {
+  background: rgba(255, 201, 107, 0.035);
+}
+
+.demo-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: end;
+  margin-bottom: 2rem;
+}
+
+.demo-heading > div {
+  max-width: 900px;
+}
+.demo-heading .family-label {
+  margin-bottom: 0.65rem;
+}
+.student-demo .eyebrow {
+  color: var(--demo-blue);
+}
+.recovery-demo .eyebrow {
+  color: var(--demo-gold);
+}
+.demo-heading h2,
+.evidence-section h2,
+.demo-final h2 {
+  margin: 0.55rem 0 0.8rem;
+  font-size: clamp(2.3rem, 5vw, 5rem);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+.demo-heading p,
+.evidence-section p,
+.demo-final p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.course-shell {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.28fr) minmax(0, 0.72fr);
+  max-width: 1380px;
+  margin: 0 auto;
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: #071b21;
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.34);
+}
+
+.course-sidebar {
+  padding: clamp(1.25rem, 3vw, 2rem);
+  border-right: 1px solid var(--line);
+  background: #0a242c;
+}
+.course-sidebar > span,
+.lesson-kicker,
+.case-box small,
+.quiz-card small,
+.panel-label,
+.progress-card > span {
+  color: var(--green);
+  font-size: 0.68rem;
+  font-weight: 950;
+  letter-spacing: 0.13em;
+}
+.course-sidebar > strong {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 1.3rem;
+}
+.course-sidebar small {
+  color: var(--muted);
+}
+.course-progress {
+  height: 7px;
+  margin: 1.4rem 0 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+.course-progress i {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--green);
+}
+.course-progress .progress-20 {
+  width: 20%;
+}
+.course-sidebar nav {
+  display: grid;
+  gap: 0.55rem;
+  margin-top: 1.6rem;
+}
+.course-sidebar nav b {
+  padding: 0.8rem;
+  border: 1px solid transparent;
+  border-radius: 0.8rem;
+  color: var(--muted);
+  font-size: 0.83rem;
+}
+.course-sidebar nav b.active {
+  border-color: rgba(85, 214, 165, 0.28);
+  background: rgba(85, 214, 165, 0.08);
+  color: #fff;
+}
+
+.course-lesson {
+  padding: clamp(1.4rem, 4vw, 3.4rem);
+}
+.course-lesson h3 {
+  max-width: 20ch;
+  margin: 0.55rem 0 1rem;
+  font-size: clamp(2rem, 4vw, 4.2rem);
+  line-height: 0.98;
+  letter-spacing: -0.05em;
+}
+.lesson-core {
+  max-width: 72ch;
+  color: #c9dcdc;
+  font-size: 1.05rem;
+}
+.case-box {
+  margin-top: 1.5rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(112, 183, 255, 0.25);
+  border-radius: 1rem;
+  background: rgba(112, 183, 255, 0.055);
+}
+.case-box p {
+  margin: 0.45rem 0 0.9rem;
+  color: #e8f3f5;
+}
+.case-box strong {
+  font-size: 0.92rem;
+  color: var(--demo-blue);
+}
+
+.quiz-card {
+  margin-top: 1.25rem;
+  padding: clamp(1.15rem, 3vw, 1.8rem);
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.025);
+}
+.quiz-card fieldset {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+.quiz-card legend {
+  margin-bottom: 0.8rem;
+  font-size: 1.12rem;
+  font-weight: 900;
+}
+.quiz-card label {
+  display: flex;
+  gap: 0.7rem;
+  align-items: flex-start;
+  padding: 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 0.75rem;
+  color: #d4e4e5;
+  cursor: pointer;
+}
+.quiz-card label:has(input:checked) {
+  border-color: rgba(85, 214, 165, 0.5);
+  background: rgba(85, 214, 165, 0.07);
+  color: #fff;
+}
+.quiz-card input {
+  margin-top: 0.2rem;
+  accent-color: var(--green);
+}
+
+.demo-button {
+  min-height: 48px;
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border: 0;
+  border-radius: 0.8rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+.demo-button.clinical {
+  background: var(--green);
+  color: #05241b;
+}
+.demo-button.student {
+  background: var(--demo-blue);
+  color: #071d32;
+}
+.demo-button.recovery {
+  width: 100%;
+  background: var(--demo-gold);
+  color: #372607;
+}
+.quiz-feedback {
+  margin-top: 0.8rem;
+  padding: 1rem;
+  border-radius: 0.8rem;
+  color: #eaf5f5;
+}
+.quiz-feedback.is-correct {
+  border: 1px solid rgba(85, 214, 165, 0.4);
+  background: rgba(85, 214, 165, 0.09);
+}
+.quiz-feedback.is-review,
+.quiz-feedback.needs-answer {
+  border: 1px solid rgba(255, 201, 107, 0.4);
+  background: rgba(255, 201, 107, 0.08);
+}
+.quiz-feedback strong {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.demo-footer-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  max-width: 1380px;
+  margin: 1rem auto 0;
+  padding: 1.1rem 1.25rem;
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.025);
+}
+.demo-footer-row p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.student-shell {
+  max-width: 1180px;
+  margin: 0 auto;
+  border: 1px solid rgba(112, 183, 255, 0.24);
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: linear-gradient(145deg, #0a2330, #0b1d28);
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.28);
+}
+.student-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--line);
+  background: rgba(0, 0, 0, 0.14);
+}
+.student-top span {
+  color: var(--muted);
+}
+.student-steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-bottom: 1px solid var(--line);
+}
+.student-steps button {
+  min-height: 54px;
+  border: 0;
+  border-right: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  font-weight: 850;
+  cursor: pointer;
+}
+.student-steps button:last-child {
+  border-right: 0;
+}
+.student-steps button.active {
+  background: rgba(112, 183, 255, 0.12);
+  color: #fff;
+  box-shadow: inset 0 -3px var(--demo-blue);
+}
+.student-panel {
+  min-height: 430px;
+  padding: clamp(1.4rem, 4vw, 3rem);
+}
+.student-panel h3 {
+  margin: 0.5rem 0 0.8rem;
+  font-size: clamp(1.8rem, 3.5vw, 3.5rem);
+  letter-spacing: -0.045em;
+}
+.student-panel > p {
+  max-width: 70ch;
+  color: var(--muted);
+}
+.prompt-box,
+.rubric-preview {
+  max-width: 800px;
+  margin: 1.3rem 0;
+  padding: 1.1rem;
+  border: 1px solid rgba(112, 183, 255, 0.25);
+  border-radius: 0.9rem;
+  background: rgba(112, 183, 255, 0.06);
+}
+.prompt-box p {
+  margin: 0.4rem 0 0;
+  color: #dce9ef;
+}
+.check-row {
+  display: flex;
+  gap: 0.75rem;
+  max-width: 800px;
+  padding: 0.8rem 0;
+  border-bottom: 1px solid var(--line);
+  color: #dce9ef;
+}
+.check-row input {
+  accent-color: var(--demo-blue);
+}
+.micro-feedback {
+  max-width: 800px;
+  padding: 0.9rem;
+  border-left: 3px solid var(--demo-blue);
+  background: rgba(112, 183, 255, 0.05);
+}
+.student-panel label[for="student-reasoning"] {
+  display: block;
+  margin: 1rem 0 0.6rem;
+  font-weight: 850;
+}
+.student-panel textarea {
+  width: 100%;
+  max-width: 900px;
+  resize: vertical;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 0.8rem;
+  background: rgba(0, 0, 0, 0.18);
+  color: #fff;
+  font: inherit;
+}
+.student-panel textarea:focus {
+  border-color: var(--demo-blue);
+  outline: 3px solid rgba(112, 183, 255, 0.2);
+}
+.writing-meta {
+  max-width: 900px;
+  margin-top: 0.35rem;
+  color: var(--muted);
+  text-align: right;
+  font-size: 0.8rem;
+}
+.rubric-preview ul {
+  color: var(--muted);
+}
+
+.browser-badge {
+  align-self: center;
+  white-space: nowrap;
+  border-color: rgba(112, 183, 255, 0.36);
+  background: rgba(112, 183, 255, 0.08);
+}
+.browser-badge.gold {
+  border-color: rgba(255, 201, 107, 0.4);
+  background: rgba(255, 201, 107, 0.08);
+  color: #fff0cd;
+}
+
+.recovery-layout {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.72fr) minmax(320px, 1.28fr);
+  gap: 1.5rem;
+  max-width: 1120px;
+  margin: 0 auto;
+  align-items: stretch;
+}
+.phone-shell {
+  padding: 1rem;
+  border: 1px solid rgba(255, 201, 107, 0.3);
+  border-radius: 2rem;
+  background: #101c1e;
+  box-shadow: 0 32px 90px rgba(0, 0, 0, 0.34);
+}
+.phone-top {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.7rem;
+  align-items: center;
+  padding: 0.6rem 0.4rem 1rem;
+}
+.phone-top > span {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 0.8rem;
+  background: var(--demo-gold);
+  color: #382606;
+  font-weight: 950;
+}
+.phone-top small {
+  color: var(--muted);
+}
+.range-field {
+  padding: 1rem 0.6rem;
+  border-top: 1px solid var(--line);
+}
+.range-field label {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-weight: 800;
+}
+.range-field output {
+  color: var(--demo-gold);
+}
+.range-field input {
+  width: 100%;
+  margin-top: 0.8rem;
+  accent-color: var(--demo-gold);
+}
+.exercise-check {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin: 0.6rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 0.9rem;
+}
+.exercise-check input {
+  accent-color: var(--demo-gold);
+}
+.exercise-check span {
+  display: grid;
+}
+.exercise-check small {
+  color: var(--muted);
+}
+.daily-summary {
+  margin-top: 0.8rem;
+  padding: 1rem;
+  border: 1px solid rgba(255, 201, 107, 0.35);
+  border-radius: 0.9rem;
+  background: rgba(255, 201, 107, 0.07);
+}
+.daily-summary p {
+  margin: 0.4rem 0;
+  color: #f7edda;
+}
+.daily-summary small {
+  color: var(--muted);
+}
+
+.progress-card {
+  display: flex;
+  flex-direction: column;
+  padding: clamp(1.4rem, 4vw, 2.5rem);
+  border: 1px solid var(--line);
+  border-radius: 1.5rem;
+  background: linear-gradient(
+    150deg,
+    rgba(67, 51, 23, 0.55),
+    rgba(7, 29, 34, 0.95)
+  );
+}
+.progress-card > span {
+  color: var(--demo-gold);
+}
+.progress-card h3 {
+  margin: 0.5rem 0;
+  font-size: clamp(2rem, 4vw, 3.6rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+.progress-card > p {
+  color: var(--muted);
+}
+.weekly-bars {
+  display: flex;
+  gap: 0.55rem;
+  align-items: end;
+  height: 190px;
+  margin: 1.4rem 0 2rem;
+  padding: 1rem 1rem 1.8rem;
+  border-left: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+.weekly-bars i {
+  position: relative;
+  flex: 1;
+  min-height: 18px;
+  border-radius: 0.45rem 0.45rem 0 0;
+  background: rgba(255, 201, 107, 0.34);
+}
+.weekly-bars i.today {
+  background: var(--demo-gold);
+}
+.weekly-bars .bar-40 {
+  height: 40%;
+}
+.weekly-bars .bar-44 {
+  height: 44%;
+}
+.weekly-bars .bar-48 {
+  height: 48%;
+}
+.weekly-bars .bar-57 {
+  height: 57%;
+}
+.weekly-bars .bar-63 {
+  height: 63%;
+}
+.weekly-bars .bar-68 {
+  height: 68%;
+}
+.weekly-bars .bar-72 {
+  height: 72%;
+}
+.weekly-bars b {
+  position: absolute;
+  left: 50%;
+  bottom: -1.55rem;
+  transform: translateX(-50%);
+  color: var(--muted);
+  font-size: 0.7rem;
+  font-style: normal;
+}
+.safety-note {
+  margin-top: auto;
+  padding: 1rem;
+  border: 1px solid rgba(255, 201, 107, 0.3);
+  border-radius: 0.9rem;
+  background: rgba(255, 201, 107, 0.065);
+}
+.safety-note p {
+  margin: 0.35rem 0 0;
+  color: #e5d8c0;
+  font-size: 0.9rem;
+}
+
+.evidence-section {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+  gap: 2rem;
+  align-items: center;
+  border-top: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.02);
+}
+.evidence-links {
+  display: grid;
+  gap: 0.75rem;
+}
+.evidence-links a {
+  min-height: 52px;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 0.8rem;
+  background: rgba(255, 255, 255, 0.03);
+  text-decoration: none;
+  font-weight: 800;
+}
+.evidence-links a:hover {
+  border-color: rgba(85, 214, 165, 0.5);
+}
+
+.demo-final {
+  padding: clamp(5rem, 10vw, 9rem) 1rem;
+  text-align: center;
+}
+.demo-final h2 {
+  max-width: 14ch;
+  margin-inline: auto;
+}
+.demo-final p {
+  max-width: 65ch;
+  margin-inline: auto;
+}
+.demo-final .actions {
+  justify-content: center;
+}
+
+@media (max-width: 900px) {
+  .demo-heading,
+  .course-shell,
+  .recovery-layout,
+  .evidence-section,
+  .demo-footer-row {
+    grid-template-columns: 1fr;
+  }
+  .course-sidebar {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+  .course-sidebar nav {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .demo-heading {
+    align-items: start;
+  }
+  .browser-badge {
+    justify-self: start;
+  }
+}
+
+@media (max-width: 700px) {
+  .demo-header nav a:not(.nav-button) {
+    display: none;
+  }
+  .demo-hero h1 {
+    font-size: 3.4rem;
+  }
+  .student-steps {
+    grid-template-columns: 1fr;
+  }
+  .student-steps button {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+  .student-top {
+    display: grid;
+  }
+  .course-sidebar nav {
+    grid-template-columns: 1fr;
+  }
+  .demo-footer-row .primary {
+    width: 100%;
+  }
+}

--- a/muestras/demo-v1.js
+++ b/muestras/demo-v1.js
@@ -1,0 +1,86 @@
+(() => {
+  "use strict";
+
+  const quiz = document.querySelector("[data-clinical-quiz]");
+  const quizFeedback = document.querySelector("[data-clinical-feedback]");
+  quiz?.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const selected = quiz.querySelector(
+      'input[name="clinical-answer"]:checked',
+    );
+    if (!selected) {
+      quizFeedback.hidden = false;
+      quizFeedback.className = "quiz-feedback needs-answer";
+      quizFeedback.textContent =
+        "Selecciona una alternativa para recibir retroalimentación.";
+      return;
+    }
+    const correct = selected.value === "2";
+    quizFeedback.hidden = false;
+    quizFeedback.className = `quiz-feedback ${correct ? "is-correct" : "is-review"}`;
+    quizFeedback.innerHTML = correct
+      ? "<strong>Decisión defendible.</strong> La utilidad está en combinar señales, estimar riesgo y vincular la información a una conducta proporcionada."
+      : "<strong>Revisa el principio.</strong> Una señal aislada no confirma ni descarta por sí sola. El riesgo se interpreta mediante combinaciones, contexto, evolución y conducta asociada.";
+  });
+
+  const stepButtons = [...document.querySelectorAll("[data-student-step]")];
+  const stepPanels = [...document.querySelectorAll("[data-student-panel]")];
+  const currentStep = document.querySelector("[data-student-current]");
+  function showStudentStep(step) {
+    stepButtons.forEach((button) => {
+      const active = button.dataset.studentStep === String(step);
+      button.classList.toggle("active", active);
+      button.setAttribute("aria-selected", String(active));
+    });
+    stepPanels.forEach((panel) => {
+      panel.hidden = panel.dataset.studentPanel !== String(step);
+    });
+    if (currentStep) currentStep.textContent = String(step);
+  }
+  stepButtons.forEach((button) =>
+    button.addEventListener("click", () =>
+      showStudentStep(button.dataset.studentStep),
+    ),
+  );
+  document
+    .querySelectorAll("[data-student-next]")
+    .forEach((button) =>
+      button.addEventListener("click", () =>
+        showStudentStep(button.dataset.studentNext),
+      ),
+    );
+
+  const reasoning = document.querySelector("#student-reasoning");
+  const reasoningCount = document.querySelector("[data-student-count]");
+  reasoning?.addEventListener("input", () => {
+    if (reasoningCount)
+      reasoningCount.textContent = String(reasoning.value.length);
+  });
+
+  const recoveryValues = { pain: 4, function: 6, sleep: 7 };
+  document.querySelectorAll("[data-recovery-range]").forEach((input) => {
+    input.addEventListener("input", () => {
+      const key = input.dataset.recoveryRange;
+      recoveryValues[key] = Number(input.value);
+      const output = document.querySelector(`[data-output="${key}"]`);
+      if (output) output.textContent = `${input.value}/10`;
+    });
+  });
+
+  const summary = document.querySelector("[data-daily-summary]");
+  document
+    .querySelector("[data-build-summary]")
+    ?.addEventListener("click", () => {
+      const completed = document.querySelector(
+        "[data-exercise-check]",
+      )?.checked;
+      const functionPhrase =
+        recoveryValues.function >= 7
+          ? "buena facilidad funcional"
+          : recoveryValues.function >= 4
+            ? "facilidad funcional intermedia"
+            : "dificultad funcional relevante";
+      summary.hidden = false;
+      summary.innerHTML = `<strong>Resumen demostrativo</strong><p>Molestia ${recoveryValues.pain}/10, ${functionPhrase} (${recoveryValues.function}/10), sueño ${recoveryValues.sleep}/10 y plan ${completed ? "realizado" : "no realizado"}.</p><small>Esta lectura organiza lo registrado; no determina una causa ni modifica un tratamiento.</small>`;
+    });
+})();

--- a/muestras/index.html
+++ b/muestras/index.html
@@ -1,0 +1,490 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      name="description"
+      content="Demostraciones funcionales de KineCheck Clínico, KineCheck Estudiante y KineCheck Recupera para conocer su enfoque antes de comprar."
+    />
+    <meta name="robots" content="index,follow,max-image-preview:large" />
+    <meta name="theme-color" content="#071d22" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_CL" />
+    <meta property="og:site_name" content="KineCheck" />
+    <meta
+      property="og:title"
+      content="Demostraciones KineCheck | Mira antes de comprar"
+    />
+    <meta
+      property="og:description"
+      content="Prueba muestras funcionales y limitadas de las tres experiencias principales de KineCheck."
+    />
+    <meta property="og:url" content="https://kinecheck.cl/muestras/" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'"
+    />
+    <link rel="canonical" href="https://kinecheck.cl/muestras/" />
+    <link rel="icon" href="../assets/kinecheck-mark.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="../kinecheck/site-v5.css?v=6" />
+    <link rel="stylesheet" href="./demo-v1.css?v=20260809-1" />
+    <script src="./demo-v1.js?v=20260809-1" defer></script>
+    <title>Demostraciones KineCheck | Mira antes de comprar</title>
+  </head>
+  <body>
+    <a class="skip-link" href="#contenido">Saltar al contenido</a>
+    <header class="site-header demo-header">
+      <a class="brand" href="../" aria-label="KineCheck inicio"
+        ><img src="../assets/kinecheck-mark.svg" alt="KineCheck" />
+        <div><strong>KineCheck</strong><small>DEMOSTRACIONES</small></div></a
+      >
+      <nav aria-label="Navegación de demostraciones">
+        <a href="#clinico">Clínico</a><a href="#estudiante">Estudiante</a
+        ><a href="#recupera">Recupera</a
+        ><a class="nav-button" href="../#productos">Ver productos</a>
+      </nav>
+    </header>
+
+    <main id="contenido">
+      <section class="demo-hero">
+        <span class="eyebrow">MIRA ANTES DE COMPRAR</span>
+        <h1>Conoce cómo se aprende, se practica y se hace seguimiento.</h1>
+        <p>
+          Estas muestras funcionales reproducen interacciones centrales de
+          KineCheck. Son públicas, limitadas y no guardan información.
+        </p>
+        <div
+          class="demo-assurances"
+          aria-label="Condiciones de la demostración"
+        >
+          <span>Sin crear cuenta</span><span>Sin guardar datos</span
+          ><span>Desde navegador</span><span>Sin instalación</span>
+        </div>
+        <div class="actions">
+          <a class="primary" href="#clinico">Comenzar demostración</a
+          ><a class="secondary" href="../#confianza"
+            >Revisar autoría y método</a
+          >
+        </div>
+      </section>
+
+      <section
+        id="clinico"
+        class="demo-section clinical-demo"
+        aria-labelledby="clinico-title"
+      >
+        <div class="demo-heading">
+          <div>
+            <span class="family-label">KINECHECK FORMACIÓN</span
+            ><span class="eyebrow">MUESTRA DE CLÍNICO</span>
+            <h2 id="clinico-title">
+              Una decisión clínica, no una diapositiva pasiva.
+            </h2>
+            <p>
+              Fragmento seleccionado del módulo 2. El curso completo incluye 10
+              módulos y 30 experiencias clínicas.
+            </p>
+          </div>
+          <a
+            class="text-link"
+            href="../productos/?producto=kinecheck-clinico#temario"
+            >Ver los 10 módulos →</a
+          >
+        </div>
+        <div class="course-shell">
+          <aside class="course-sidebar" aria-label="Contexto de la muestra">
+            <span>CURSO PROFESIONAL</span><strong>KineCheck Clínico</strong>
+            <div class="course-progress"><i class="progress-20"></i></div>
+            <small>Módulo 2 de 10 · Experiencia 1 de 3</small>
+            <nav>
+              <b class="active">1 · Caso y riesgo</b><b>2 · Decisión</b
+              ><b>3 · Retroalimentación</b>
+            </nav>
+          </aside>
+          <article class="course-lesson">
+            <span class="lesson-kicker"
+              >SEGURIDAD, TRIAGE Y PATOLOGÍA RELEVANTE</span
+            >
+            <h3>Banderas rojas: señales, combinaciones y contexto</h3>
+            <p class="lesson-core">
+              Una bandera roja aislada suele tener capacidad diagnóstica
+              limitada. Su valor aumenta al combinarse con evolución,
+              antecedentes, signos sistémicos y hallazgos del examen.
+            </p>
+            <div class="case-box">
+              <small>CASO SIMULADO</small>
+              <p>
+                Dolor lumbar reciente en una persona de 72 años, uso prolongado
+                de corticoides y dolor después de una caída menor.
+              </p>
+              <strong
+                >Tarea: construye una representación del problema y define la
+                conducta inicial.</strong
+              >
+            </div>
+            <form class="quiz-card" data-clinical-quiz>
+              <fieldset>
+                <legend>¿Qué principio es más seguro?</legend>
+                <label
+                  ><input type="radio" name="clinical-answer" value="0" /> Toda
+                  bandera roja obliga a urgencias.</label
+                ><label
+                  ><input type="radio" name="clinical-answer" value="1" /> Una
+                  bandera roja nunca es útil.</label
+                ><label
+                  ><input type="radio" name="clinical-answer" value="2" /> Las
+                  señales deben integrarse y vincularse a una conducta
+                  proporcional.</label
+                ><label
+                  ><input type="radio" name="clinical-answer" value="3" /> Una
+                  prueba física negativa elimina patología grave.</label
+                >
+              </fieldset>
+              <button class="demo-button clinical" type="submit">
+                Comprobar decisión
+              </button>
+              <div
+                class="quiz-feedback"
+                data-clinical-feedback
+                role="status"
+                hidden
+              ></div>
+            </form>
+          </article>
+        </div>
+        <div class="demo-footer-row">
+          <p>
+            <strong>Qué demuestra:</strong> el curso solicita representar el
+            problema, decidir y justificar; después entrega una explicación, no
+            solo una marca correcta o incorrecta.
+          </p>
+          <a class="primary" href="../productos/?producto=kinecheck-clinico"
+            >Revisar ficha completa</a
+          >
+        </div>
+      </section>
+
+      <section
+        id="estudiante"
+        class="demo-section student-demo"
+        aria-labelledby="student-title"
+      >
+        <div class="demo-heading">
+          <div>
+            <span class="family-label">KINECHECK APPS · APLICACIÓN WEB</span
+            ><span class="eyebrow">MUESTRA DE ESTUDIANTE</span>
+            <h2 id="student-title">
+              Una ruta que pregunta por qué antes de avanzar.
+            </h2>
+            <p>
+              Simulación pública representativa del flujo guiado. Funciona en el
+              navegador y no guarda lo que escribas.
+            </p>
+          </div>
+          <span class="browser-badge">SIN INSTALACIÓN</span>
+        </div>
+        <div class="student-shell">
+          <div class="student-top">
+            <strong>Práctica guiada · Caso simulado</strong
+            ><span>Paso <b data-student-current>1</b> de 3</span>
+          </div>
+          <div
+            class="student-steps"
+            role="tablist"
+            aria-label="Pasos de la muestra"
+          >
+            <button
+              type="button"
+              class="active"
+              data-student-step="1"
+              role="tab"
+              aria-selected="true"
+            >
+              1. Comprender</button
+            ><button
+              type="button"
+              data-student-step="2"
+              role="tab"
+              aria-selected="false"
+            >
+              2. Priorizar</button
+            ><button
+              type="button"
+              data-student-step="3"
+              role="tab"
+              aria-selected="false"
+            >
+              3. Justificar
+            </button>
+          </div>
+          <div class="student-panel" data-student-panel="1">
+            <span class="panel-label">CASO</span>
+            <h3>Dolor de rodilla después de un giro</h3>
+            <p>
+              Estudiante de 21 años, dolor desde hace cuatro días después de
+              girar jugando fútbol. Puede apoyar, refiere derrame leve y teme
+              haber “roto algo”.
+            </p>
+            <div class="prompt-box">
+              <strong>Antes de elegir pruebas:</strong>
+              <p>
+                ¿Qué información falta para representar el problema y decidir si
+                el examen puede continuar con seguridad?
+              </p>
+            </div>
+            <button
+              type="button"
+              class="demo-button student"
+              data-student-next="2"
+            >
+              Continuar a seguridad
+            </button>
+          </div>
+          <div class="student-panel" data-student-panel="2" hidden>
+            <span class="panel-label">PRIORIZA</span>
+            <h3>Selecciona lo que revisarías primero.</h3>
+            <label class="check-row"
+              ><input type="checkbox" /> Capacidad para apoyar y caminar</label
+            ><label class="check-row"
+              ><input type="checkbox" /> Trauma, deformidad y bloqueo
+              verdadero</label
+            ><label class="check-row"
+              ><input type="checkbox" /> Síntomas sistémicos o deterioro
+              rápido</label
+            ><label class="check-row"
+              ><input type="checkbox" /> Color favorito para distraer al
+              paciente</label
+            >
+            <p class="micro-feedback">
+              La aplicación no elige por ti: te obliga a distinguir información
+              relevante de datos que no modifican la decisión.
+            </p>
+            <button
+              type="button"
+              class="demo-button student"
+              data-student-next="3"
+            >
+              Continuar a justificación
+            </button>
+          </div>
+          <div class="student-panel" data-student-panel="3" hidden>
+            <span class="panel-label">JUSTIFICA</span>
+            <h3>Explica tu siguiente paso.</h3>
+            <label for="student-reasoning"
+              >¿Qué examinarías primero y qué resultado cambiaría tu
+              conducta?</label
+            ><textarea
+              id="student-reasoning"
+              rows="5"
+              maxlength="400"
+              placeholder="Escribe una justificación breve…"
+            ></textarea>
+            <div class="writing-meta">
+              <span data-student-count>0</span>/400 caracteres
+            </div>
+            <div class="rubric-preview">
+              <strong>La retroalimentación revisa si:</strong>
+              <ul>
+                <li>priorizas seguridad antes que una etiqueta;</li>
+                <li>relacionas el examen con la historia;</li>
+                <li>explicas qué hallazgo cambiaría la conducta.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="demo-footer-row">
+          <p>
+            <strong>Qué demuestra:</strong> Estudiante organiza el proceso,
+            solicita justificar decisiones y hace visibles las omisiones sin
+            reemplazar la supervisión docente.
+          </p>
+          <a class="primary" href="../productos/?producto=kinecheck-estudiante"
+            >Revisar ficha completa</a
+          >
+        </div>
+      </section>
+
+      <section
+        id="recupera"
+        class="demo-section recovery-demo"
+        aria-labelledby="recovery-title"
+      >
+        <div class="demo-heading">
+          <div>
+            <span class="family-label">KINECHECK APPS · APLICACIÓN WEB</span
+            ><span class="eyebrow">MUESTRA DE RECUPERA</span>
+            <h2 id="recovery-title">
+              Un registro breve que convierte la semana en información útil.
+            </h2>
+            <p>
+              Mueve los controles para ver cómo se resume un día. Nada se guarda
+              ni se envía.
+            </p>
+          </div>
+          <span class="browser-badge gold">SIN INSTALACIÓN</span>
+        </div>
+        <div class="recovery-layout">
+          <div class="phone-shell">
+            <div class="phone-top">
+              <span>KR</span><strong>¿Cómo estás hoy?</strong
+              ><small>Demostración</small>
+            </div>
+            <div class="range-field">
+              <label for="pain-range"
+                ><span>Molestia</span
+                ><output data-output="pain">4/10</output></label
+              ><input
+                id="pain-range"
+                data-recovery-range="pain"
+                type="range"
+                min="0"
+                max="10"
+                value="4"
+              />
+            </div>
+            <div class="range-field">
+              <label for="function-range"
+                ><span>Facilidad para tu actividad</span
+                ><output data-output="function">6/10</output></label
+              ><input
+                id="function-range"
+                data-recovery-range="function"
+                type="range"
+                min="0"
+                max="10"
+                value="6"
+              />
+            </div>
+            <div class="range-field">
+              <label for="sleep-range"
+                ><span>Calidad del sueño</span
+                ><output data-output="sleep">7/10</output></label
+              ><input
+                id="sleep-range"
+                data-recovery-range="sleep"
+                type="range"
+                min="0"
+                max="10"
+                value="7"
+              />
+            </div>
+            <label class="exercise-check"
+              ><input type="checkbox" data-exercise-check checked /><span
+                ><strong>Plan realizado</strong
+                ><small>Ejercicios indicados por tu profesional</small></span
+              ></label
+            >
+            <button
+              class="demo-button recovery"
+              type="button"
+              data-build-summary
+            >
+              Ver resumen del día
+            </button>
+            <div
+              class="daily-summary"
+              data-daily-summary
+              role="status"
+              hidden
+            ></div>
+          </div>
+          <aside class="progress-card">
+            <span>MI PROGRESO · EJEMPLO</span>
+            <h3>Una tendencia, no un diagnóstico.</h3>
+            <div
+              class="weekly-bars"
+              aria-label="Gráfico ilustrativo de función durante siete días"
+            >
+              <i class="bar-40"><b>L</b></i><i class="bar-48"><b>M</b></i
+              ><i class="bar-44"><b>X</b></i><i class="bar-57"><b>J</b></i
+              ><i class="bar-63"><b>V</b></i><i class="bar-68"><b>S</b></i
+              ><i class="today bar-72"><b>D</b></i>
+            </div>
+            <p>
+              KineCheck Recupera ayuda a observar síntomas, función, sueño y
+              cumplimiento para conversar con mayor claridad con el profesional.
+            </p>
+            <div class="safety-note">
+              <strong>Importante</strong>
+              <p>
+                No diagnostica, no prescribe ejercicios y no reemplaza una
+                evaluación ni una urgencia de salud.
+              </p>
+            </div>
+          </aside>
+        </div>
+        <div class="demo-footer-row">
+          <p>
+            <strong>Qué demuestra:</strong> Recupera usa lenguaje cotidiano,
+            seguimiento multidimensional y resúmenes simples; no interpreta los
+            datos como un diagnóstico.
+          </p>
+          <a class="primary" href="../productos/?producto=kinecheck-recupera"
+            >Revisar ficha completa</a
+          >
+        </div>
+      </section>
+
+      <section class="evidence-section" aria-labelledby="evidence-title">
+        <div>
+          <span class="eyebrow">TRANSPARENCIA</span>
+          <h2 id="evidence-title">
+            La muestra también permite revisar el criterio.
+          </h2>
+          <p>
+            En el curso completo, las referencias aparecen vinculadas a las
+            decisiones que sustentan. Entre las fuentes incorporadas se
+            encuentran recomendaciones transversales para dolor
+            musculoesquelético, la guía OMS para dolor lumbar crónico y el marco
+            cervical IFOMPT.
+          </p>
+        </div>
+        <div class="evidence-links">
+          <a
+            href="https://pubmed.ncbi.nlm.nih.gov/30826805/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Buenas prácticas MSK · BJSM</a
+          ><a
+            href="https://www.who.int/publications/i/item/9789240081789"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Guía OMS · dolor lumbar</a
+          ><a
+            href="https://pubmed.ncbi.nlm.nih.gov/36099171/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Marco cervical IFOMPT</a
+          >
+        </div>
+      </section>
+
+      <section class="demo-final">
+        <span class="eyebrow">¿NECESITAS AYUDA?</span>
+        <h2>Compara con calma antes de decidir.</h2>
+        <p>
+          Revisa temario, precio, vigencia, metodología y condiciones postventa.
+          Si aún tienes una duda, utiliza el centro de soporte.
+        </p>
+        <div class="actions">
+          <a class="primary" href="../#productos">Comparar productos</a
+          ><a class="secondary" href="../soporte/">Abrir soporte</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="brand">
+        <img src="../assets/kinecheck-mark.svg" alt="KineCheck" />
+        <div>
+          <strong>KineCheck</strong><small>SALUD MUSCULOESQUELÉTICA</small>
+        </div>
+      </div>
+      <p>
+        Demostraciones públicas · No guardan datos ·
+        <a href="../legal/terminos.html">Términos</a>
+      </p>
+    </footer>
+  </body>
+</html>

--- a/productos/index.html
+++ b/productos/index.html
@@ -18,6 +18,7 @@
   <link rel="canonical" href="https://kinecheck.cl/productos/">
   <link rel="stylesheet" href="./product.css?v=20260808-rc1">
   <link rel="stylesheet" href="./product-responsive-fix.css?v=20260808-1">
+  <link rel="stylesheet" href="./product-trust-v2.css?v=20260809-1">
   <script src="./product.js?v=20260805-legal1" defer></script>
   <script src="./product-clinico-reposition-v1.js?v=20260806-1" defer></script>
   <title>KineCheck Clínico | Curso profesional y guía complementaria</title>
@@ -39,12 +40,13 @@
   <section class="product-hero" aria-labelledby="product-title">
     <div class="hero-inner">
       <div class="breadcrumbs"><a href="../">Inicio</a><span aria-hidden="true">›</span><a data-catalog href="../#productos">Productos</a><span aria-hidden="true">›</span><strong id="breadcrumb-name">Clínico</strong></div>
-      <div class="hero-badges"><span id="product-family">KINECHECK APPS</span><span id="product-type">CURSO PROFESIONAL + GUÍA COMPLEMENTARIA</span><span id="product-term">12 MESES</span><span>ACCESO PERSONAL</span><span>ONLINE</span></div>
+      <div class="hero-badges"><span id="product-family">KINECHECK FORMACIÓN</span><span id="product-type">CURSO PROFESIONAL + GUÍA COMPLEMENTARIA</span><span id="product-term">12 MESES</span><span>ACCESO PERSONAL</span><span>ONLINE</span></div>
       <h1 id="product-title"><em>KineCheck</em> Clínico</h1>
       <p id="product-subtitle" class="hero-subtitle">Evaluación, seguridad y razonamiento musculoesquelético</p>
       <p id="product-description" class="hero-description">Formación avanzada para kinesiólogos y profesionales de rehabilitación. El curso es el centro del producto; la guía digital adjunta ayuda a revisar el proceso sin competir con la ficha clínica institucional.</p>
       <div class="hero-actions">
         <a class="button primary" data-checkout href="https://pay.hotmart.com/L106791841D" target="_blank" rel="noopener noreferrer">Comprar en Hotmart</a>
+        <a class="button secondary" data-clinico-only href="../muestras/#clinico">Ver una muestra</a>
         <a class="button secondary" data-access href="../academy/">Ya compré: ingresar</a>
         <a class="button ghost" data-catalog href="../#productos">Comparar productos</a>
       </div>
@@ -52,7 +54,7 @@
   </section>
 
   <div class="quick-facts" aria-label="Características del producto">
-    <article class="fact"><small>FORMATO</small><strong>Experiencia online y responsiva</strong></article>
+    <article class="fact"><small>FORMATO</small><strong id="fact-format">Curso profesional + guía complementaria</strong></article>
     <article class="fact"><small>VIGENCIA</small><strong id="fact-term">12 meses desde la aprobación</strong></article>
     <article class="fact"><small>ACCESO</small><strong>Correo asociado a la compra</strong></article>
     <article class="fact"><small>SOPORTE</small><strong>soporte.kinecheck@gmail.com</strong></article>
@@ -99,6 +101,93 @@
         <article class="list-card"><strong>Seguridad y triage</strong><p>Banderas rojas, examen neurológico y marco cervical IFOMPT.</p></article>
         <article class="list-card"><strong>Guía digital adjunta</strong><p>Apoyo para revisar preguntas, hallazgos e hipótesis. No es una ficha clínica oficial ni un repositorio de pacientes.</p></article>
       </div>
+    </section>
+
+    <section id="temario" class="section" data-clinico-only aria-labelledby="syllabus-title">
+      <div class="section-heading">
+        <span class="eyebrow">TEMARIO COMPLETO</span>
+        <h2 id="syllabus-title">10 módulos para aprender a evaluar y decidir.</h2>
+        <p>18 horas estimadas, 30 experiencias clínicas y una secuencia que avanza desde el estándar profesional hasta la reevaluación y el cierre del razonamiento.</p>
+      </div>
+      <div class="module-grid">
+        <details class="module-card" open>
+          <summary><span>01</span><strong>La guía complementaria y el estándar profesional</strong></summary>
+          <p>Delimita qué problema resuelve KineCheck Clínico, qué no debe hacer y cómo integrarlo sin competir con la ficha clínica institucional.</p>
+        </details>
+        <details class="module-card">
+          <summary><span>02</span><strong>Seguridad, triage y detección de patología relevante</strong></summary>
+          <p>Prioriza condiciones que requieren derivación, precaución o modificación antes de profundizar en el diagnóstico musculoesquelético.</p>
+        </details>
+        <details class="module-card">
+          <summary><span>03</span><strong>Historia clínica, comportamiento de síntomas e irritabilidad</strong></summary>
+          <p>Transforma la anamnesis en una representación útil del problema sin rigidizarla en una secuencia de preguntas.</p>
+        </details>
+        <details class="module-card">
+          <summary><span>04</span><strong>Persona, contexto y factores psicosociales</strong></summary>
+          <p>Integra valores, expectativas, salud mental, sueño, trabajo y participación sin reducir la experiencia a etiquetas.</p>
+        </details>
+        <details class="module-card">
+          <summary><span>05</span><strong>Examen físico orientado por hipótesis</strong></summary>
+          <p>Selecciona observación, movimiento, palpación y pruebas según seguridad, irritabilidad y utilidad decisional.</p>
+        </details>
+        <details class="module-card">
+          <summary><span>06</span><strong>Medición: movilidad, fuerza y desempeño</strong></summary>
+          <p>Obtiene medidas comparables, interpreta el error y elige instrumentos que realmente cambian decisiones.</p>
+        </details>
+        <details class="module-card">
+          <summary><span>07</span><strong>Examen neurológico y neurodinámica</strong></summary>
+          <p>Evalúa función neural y mecanosensibilidad sin convertir pruebas provocativas en diagnósticos.</p>
+        </details>
+        <details class="module-card">
+          <summary><span>08</span><strong>Pruebas especiales, clusters y razonamiento probabilístico</strong></summary>
+          <p>Interpreta exactitud diagnóstica, probabilidad previa y aplicabilidad sin sobrevalorar etiquetas anatómicas.</p>
+        </details>
+        <details class="module-card">
+          <summary><span>09</span><strong>Integración CIF, hipótesis, diagnóstico y pronóstico</strong></summary>
+          <p>Convierte datos en una representación del problema, prioridades y un plan revisable centrado en función y participación.</p>
+        </details>
+        <details class="module-card">
+          <summary><span>10</span><strong>Seguimiento, resultados y cierre del razonamiento</strong></summary>
+          <p>Mide cambio relevante, revisa hipótesis y produce una síntesis útil para la continuidad de cuidados.</p>
+        </details>
+      </div>
+    </section>
+
+    <section id="metodologia" class="section" data-clinico-only aria-labelledby="method-title">
+      <div class="section-heading">
+        <span class="eyebrow">AUTORÍA Y METODOLOGÍA</span>
+        <h2 id="method-title">Contenido con responsable, método y fuentes visibles.</h2>
+        <p>La formación no se presenta como una colección anónima de diapositivas: cada módulo explicita qué se aprende, cómo se practica y con qué referencias se sustenta.</p>
+      </div>
+      <div class="confidence-grid">
+        <article class="author-panel">
+          <div class="author-mark" aria-hidden="true">EZ</div>
+          <div><span>AUTOR Y DESARROLLADOR</span><h3>Emmanuel Zúñiga</h3><p>Kinesiólogo, Magíster en Docencia para la Educación Superior y docente universitario, con experiencia clínica musculoesquelética y diseño de formación aplicada.</p></div>
+        </article>
+        <article class="method-panel"><span>METODOLOGÍA DE APRENDIZAJE</span><h3>Casos activos, no consumo pasivo.</h3><p>Cada módulo combina objetivos, lecciones, casos simulados, tareas de razonamiento, evidencia, preguntas de comprobación y retroalimentación explicada.</p></article>
+        <article class="method-panel"><span>BASE CIENTÍFICA</span><h3>Referencias trazables.</h3><p>Integra guías clínicas, marcos internacionales y revisiones sobre seguridad, medición, pruebas diagnósticas, resultados y educación del razonamiento clínico.</p></article>
+        <article class="method-panel"><span>SOPORTE Y ACTUALIZACIONES</span><h3>Acompañamiento durante el acceso.</h3><p>Soporte para acceso, licencia, navegación y contenido. Objetivo de respuesta inicial: dentro de 2 días hábiles. Las correcciones y mejoras quedan disponibles durante la vigencia activa.</p><a href="../soporte/">Abrir centro de soporte →</a></article>
+      </div>
+      <article class="sample-panel" aria-labelledby="sample-title">
+        <div class="sample-copy">
+          <span class="eyebrow">MUESTRA DE UNA EXPERIENCIA CLÍNICA</span>
+          <h3 id="sample-title">Banderas rojas: señales, combinaciones y contexto</h3>
+          <p><strong>Caso simulado:</strong> dolor lumbar reciente en una persona de 72 años, uso prolongado de corticoides y dolor después de una caída menor.</p>
+          <p>La tarea no pide memorizar una etiqueta: solicita construir una representación del problema, justificar la prioridad y definir una conducta proporcional al riesgo.</p>
+          <div class="sample-tags"><span>Historia clínica</span><span>Seguridad</span><span>Decisión</span><span>Retroalimentación</span></div>
+        </div>
+        <div class="sample-question">
+          <small>COMPROBACIÓN FORMATIVA</small>
+          <strong>¿Qué principio es más seguro?</strong>
+          <ol>
+            <li>Toda bandera roja obliga a urgencias.</li>
+            <li>Una bandera roja nunca es útil.</li>
+            <li class="correct">Integrar las señales y vincularlas a una conducta proporcional.</li>
+            <li>Una prueba física negativa elimina patología grave.</li>
+          </ol>
+          <a class="button primary" href="../muestras/#clinico">Probar la muestra interactiva</a>
+        </div>
+      </article>
     </section>
 
     <section class="section">

--- a/productos/kinecheck-clinico/index.html
+++ b/productos/kinecheck-clinico/index.html
@@ -8,10 +8,7 @@
       content="KineCheck Clínico: curso profesional avanzado de evaluación, seguridad y razonamiento musculoesquelético con guía digital complementaria."
     />
     <meta name="robots" content="index,follow,max-image-preview:large" />
-    <link
-      rel="canonical"
-      href="https://kinecheck.cl/productos/kinecheck-clinico/"
-    />
+    <link rel="canonical" href="https://kinecheck.cl/productos/kinecheck-clinico/">
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_CL" />
     <meta property="og:site_name" content="KineCheck" />

--- a/productos/kinecheck-clinico/index.html
+++ b/productos/kinecheck-clinico/index.html
@@ -1,1 +1,97 @@
-<!doctype html><html lang="es"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="description" content="KineCheck Clínico: curso profesional avanzado de evaluación, seguridad y razonamiento musculoesquelético con guía digital complementaria."><meta name="robots" content="index,follow,max-image-preview:large"><link rel="canonical" href="https://kinecheck.cl/productos/kinecheck-clinico/"><meta property="og:type" content="website"><meta property="og:locale" content="es_CL"><meta property="og:site_name" content="KineCheck"><meta property="og:title" content="KineCheck Clínico | Curso profesional"><meta property="og:description" content="Evaluación, seguridad y razonamiento musculoesquelético con guía digital complementaria."><meta property="og:url" content="https://kinecheck.cl/productos/kinecheck-clinico/"><title>KineCheck Clínico | Curso profesional</title><link rel="icon" href="../../assets/kinecheck-mark.svg" type="image/svg+xml"><link rel="stylesheet" href="../../kinecheck/site-v5.css?v=6"><script type="application/ld+json">{"@context":"https://schema.org","@type":"Course","name":"KineCheck Clínico","description":"Curso profesional avanzado de evaluación, seguridad y razonamiento musculoesquelético con guía digital complementaria.","provider":{"@type":"Organization","name":"KineCheck","url":"https://kinecheck.cl/"},"offers":{"@type":"Offer","price":"39990","priceCurrency":"CLP","url":"https://pay.hotmart.com/L106791841D","availability":"https://schema.org/InStock"}}</script></head><body><header class="site-header"><a class="brand" href="../../"><img src="../../assets/kinecheck-mark.svg" alt="KineCheck"><div><strong>KineCheck</strong><small>FORMACIÓN</small></div></a><nav><a href="../../profesionales/">Profesionales</a><a href="../../academy/">Ingresar</a></nav></header><main><section class="page-hero"><span class="eyebrow">KINECHECK CLÍNICO</span><h1>Evalúa con estructura. Razona con criterio.</h1><p>Curso profesional avanzado de evaluación, seguridad y razonamiento musculoesquelético. Incluye una guía digital complementaria para aplicar el método aprendido sin reemplazar la ficha clínica institucional.</p><div class="price"><small>Pago único</small><strong>$39.990 CLP</strong><span>Acceso por 12 meses</span></div><div class="actions"><a class="primary" href="https://pay.hotmart.com/L106791841D" target="_blank" rel="noopener noreferrer">Comprar en Hotmart</a><a class="secondary" href="../?producto=kinecheck-clinico">Ver ficha completa</a></div></section></main><footer><p>KineCheck · Salud musculoesquelética</p></footer></body></html>
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      name="description"
+      content="KineCheck Clínico: curso profesional avanzado de evaluación, seguridad y razonamiento musculoesquelético con guía digital complementaria."
+    />
+    <meta name="robots" content="index,follow,max-image-preview:large" />
+    <link
+      rel="canonical"
+      href="https://kinecheck.cl/productos/kinecheck-clinico/"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_CL" />
+    <meta property="og:site_name" content="KineCheck" />
+    <meta property="og:title" content="KineCheck Clínico | Curso profesional" />
+    <meta
+      property="og:description"
+      content="Evaluación, seguridad y razonamiento musculoesquelético con guía digital complementaria."
+    />
+    <meta
+      property="og:url"
+      content="https://kinecheck.cl/productos/kinecheck-clinico/"
+    />
+    <title>KineCheck Clínico | Curso profesional</title>
+    <link
+      rel="icon"
+      href="../../assets/kinecheck-mark.svg"
+      type="image/svg+xml"
+    />
+    <link rel="stylesheet" href="../../kinecheck/site-v5.css?v=6" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Course",
+        "name": "KineCheck Clínico",
+        "description": "Curso profesional avanzado de evaluación, seguridad y razonamiento musculoesquelético con guía digital complementaria.",
+        "provider": {
+          "@type": "Organization",
+          "name": "KineCheck",
+          "url": "https://kinecheck.cl/"
+        },
+        "offers": {
+          "@type": "Offer",
+          "price": "39990",
+          "priceCurrency": "CLP",
+          "url": "https://pay.hotmart.com/L106791841D",
+          "availability": "https://schema.org/InStock"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="../../"
+        ><img src="../../assets/kinecheck-mark.svg" alt="KineCheck" />
+        <div><strong>KineCheck</strong><small>FORMACIÓN</small></div></a
+      >
+      <nav>
+        <a href="../../profesionales/">Profesionales</a
+        ><a href="../../academy/">Ingresar</a>
+      </nav>
+    </header>
+    <main>
+      <section class="page-hero">
+        <span class="eyebrow">KINECHECK CLÍNICO</span>
+        <h1>Evalúa con estructura. Razona con criterio.</h1>
+        <p>
+          Curso profesional avanzado de evaluación, seguridad y razonamiento
+          musculoesquelético. Incluye una guía digital complementaria para
+          aplicar el método aprendido sin reemplazar la ficha clínica
+          institucional.
+        </p>
+        <div class="price">
+          <small>Pago único</small><strong>$39.990 CLP</strong
+          ><span>Acceso por 12 meses</span>
+        </div>
+        <div class="actions">
+          <a
+            class="primary"
+            href="https://pay.hotmart.com/L106791841D"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Comprar en Hotmart</a
+          ><a class="secondary" href="../?producto=kinecheck-clinico"
+            >Ver ficha completa</a
+          ><a class="secondary" href="../../muestras/#clinico"
+            >Ver demostración</a
+          >
+        </div>
+      </section>
+    </main>
+    <footer><p>KineCheck · Salud musculoesquelética</p></footer>
+  </body>
+</html>

--- a/productos/kinecheck-estudiante/index.html
+++ b/productos/kinecheck-estudiante/index.html
@@ -8,10 +8,7 @@
       content="KineCheck Estudiante: aplicación web guiada para aprender evaluación y razonamiento clínico paso a paso, sin instalación."
     />
     <meta name="robots" content="index,follow,max-image-preview:large" />
-    <link
-      rel="canonical"
-      href="https://kinecheck.cl/productos/kinecheck-estudiante/"
-    />
+    <link rel="canonical" href="https://kinecheck.cl/productos/kinecheck-estudiante/">
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_CL" />
     <meta property="og:site_name" content="KineCheck" />

--- a/productos/kinecheck-estudiante/index.html
+++ b/productos/kinecheck-estudiante/index.html
@@ -1,1 +1,98 @@
-<!doctype html><html lang="es"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="description" content="KineCheck Estudiante: aplicación guiada para aprender evaluación y razonamiento clínico paso a paso."><meta name="robots" content="index,follow,max-image-preview:large"><link rel="canonical" href="https://kinecheck.cl/productos/kinecheck-estudiante/"><meta property="og:type" content="website"><meta property="og:locale" content="es_CL"><meta property="og:site_name" content="KineCheck"><meta property="og:title" content="KineCheck Estudiante | Evaluación clínica guiada"><meta property="og:description" content="Aprende evaluación musculoesquelética y razonamiento clínico paso a paso."><meta property="og:url" content="https://kinecheck.cl/productos/kinecheck-estudiante/"><title>KineCheck Estudiante | Evaluación clínica guiada</title><link rel="icon" href="../../assets/kinecheck-mark.svg" type="image/svg+xml"><link rel="stylesheet" href="../../kinecheck/site-v5.css?v=6"><script type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"KineCheck Estudiante","description":"Aplicación guiada para aprender evaluación y razonamiento clínico paso a paso.","brand":{"@type":"Brand","name":"KineCheck"},"offers":{"@type":"Offer","price":"14990","priceCurrency":"CLP","url":"https://pay.hotmart.com/G106801166S","availability":"https://schema.org/InStock"}}</script></head><body><header class="site-header"><a class="brand" href="../../"><img src="../../assets/kinecheck-mark.svg" alt="KineCheck"><div><strong>KineCheck</strong><small>ESTUDIANTES</small></div></a><nav><a href="../../estudiantes/">Estudiantes</a><a href="../../academy/">Ingresar</a></nav></header><main><section class="page-hero est"><span class="eyebrow">KINECHECK ESTUDIANTE</span><h1>Aprende a evaluar con una ruta guiada.</h1><p>Aplicación formativa para conectar entrevista, examen físico, contexto y razonamiento clínico de manera progresiva.</p><div class="price"><small>Pago único</small><strong>$14.990 CLP</strong><span>Acceso por 12 meses</span></div><div class="actions"><a class="primary" href="https://pay.hotmart.com/G106801166S" target="_blank" rel="noopener noreferrer">Comprar en Hotmart</a><a class="secondary" href="../?producto=kinecheck-estudiante">Ver ficha completa</a></div></section></main><footer><p>KineCheck · Salud musculoesquelética</p></footer></body></html>
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      name="description"
+      content="KineCheck Estudiante: aplicación web guiada para aprender evaluación y razonamiento clínico paso a paso, sin instalación."
+    />
+    <meta name="robots" content="index,follow,max-image-preview:large" />
+    <link
+      rel="canonical"
+      href="https://kinecheck.cl/productos/kinecheck-estudiante/"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_CL" />
+    <meta property="og:site_name" content="KineCheck" />
+    <meta
+      property="og:title"
+      content="KineCheck Estudiante | Evaluación clínica guiada"
+    />
+    <meta
+      property="og:description"
+      content="Aprende evaluación musculoesquelética y razonamiento clínico paso a paso."
+    />
+    <meta
+      property="og:url"
+      content="https://kinecheck.cl/productos/kinecheck-estudiante/"
+    />
+    <title>KineCheck Estudiante | Evaluación clínica guiada</title>
+    <link
+      rel="icon"
+      href="../../assets/kinecheck-mark.svg"
+      type="image/svg+xml"
+    />
+    <link rel="stylesheet" href="../../kinecheck/site-v5.css?v=6" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": "KineCheck Estudiante",
+        "description": "Aplicación web guiada para aprender evaluación y razonamiento clínico paso a paso, sin instalación.",
+        "brand": { "@type": "Brand", "name": "KineCheck" },
+        "offers": {
+          "@type": "Offer",
+          "price": "14990",
+          "priceCurrency": "CLP",
+          "url": "https://pay.hotmart.com/G106801166S",
+          "availability": "https://schema.org/InStock"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="../../"
+        ><img src="../../assets/kinecheck-mark.svg" alt="KineCheck" />
+        <div><strong>KineCheck</strong><small>ESTUDIANTES</small></div></a
+      >
+      <nav>
+        <a href="../../estudiantes/">Estudiantes</a
+        ><a href="../../academy/">Ingresar</a>
+      </nav>
+    </header>
+    <main>
+      <section class="page-hero est">
+        <span class="family-label"
+          >KINECHECK APPS · APLICACIÓN WEB · SIN INSTALACIÓN</span
+        >
+        <span class="eyebrow">KINECHECK ESTUDIANTE</span>
+        <h1>Aprende a evaluar con una ruta guiada.</h1>
+        <p>
+          Aplicación web formativa para conectar entrevista, examen físico,
+          contexto y razonamiento clínico de manera progresiva. Accede desde
+          navegador, sin instalación.
+        </p>
+        <div class="price">
+          <small>Pago único</small><strong>$14.990 CLP</strong
+          ><span>Acceso por 12 meses</span>
+        </div>
+        <div class="actions">
+          <a
+            class="primary"
+            href="https://pay.hotmart.com/G106801166S"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Comprar en Hotmart</a
+          ><a class="secondary" href="../?producto=kinecheck-estudiante"
+            >Ver ficha completa</a
+          ><a class="secondary" href="../../muestras/#estudiante"
+            >Ver demostración</a
+          >
+        </div>
+      </section>
+    </main>
+    <footer><p>KineCheck · Salud musculoesquelética</p></footer>
+  </body>
+</html>

--- a/productos/kinecheck-recupera/index.html
+++ b/productos/kinecheck-recupera/index.html
@@ -1,1 +1,99 @@
-<!doctype html><html lang="es"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="description" content="KineCheck Recupera: seguimiento personal de síntomas, función, sueño, ejercicios y progreso durante la recuperación."><meta name="robots" content="index,follow,max-image-preview:large"><link rel="canonical" href="https://kinecheck.cl/productos/kinecheck-recupera/"><meta property="og:type" content="website"><meta property="og:locale" content="es_CL"><meta property="og:site_name" content="KineCheck"><meta property="og:title" content="KineCheck Recupera | Seguimiento de recuperación"><meta property="og:description" content="Registra cómo te has sentido, sigue tu plan y observa tu progreso. No diagnostica ni reemplaza la atención profesional."><meta property="og:url" content="https://kinecheck.cl/productos/kinecheck-recupera/"><title>KineCheck Recupera | Seguimiento de recuperación</title><link rel="icon" href="../../assets/kinecheck-mark.svg" type="image/svg+xml"><link rel="stylesheet" href="../../kinecheck/site-v5.css?v=6"><script type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"KineCheck Recupera","description":"Aplicación de seguimiento personal de síntomas, función, sueño, ejercicios y progreso. No diagnostica ni prescribe.","brand":{"@type":"Brand","name":"KineCheck"},"offers":{"@type":"Offer","price":"9990","priceCurrency":"CLP","url":"https://pay.hotmart.com/P106806251E","availability":"https://schema.org/InStock"}}</script></head><body><header class="site-header"><a class="brand" href="../../"><img src="../../assets/kinecheck-mark.svg" alt="KineCheck"><div><strong>KineCheck</strong><small>RECUPERA</small></div></a><nav><a href="../../recupera/">Recupera</a><a href="../../academy/">Ingresar</a></nav></header><main><section class="page-hero rec"><span class="eyebrow">KINECHECK RECUPERA</span><h1>Haz visible tu progreso.</h1><p>Seguimiento personal para registrar síntomas, función, sueño, ejercicios y evolución. KineCheck Recupera no diagnostica, no prescribe tratamientos y no reemplaza una atención profesional.</p><div class="price"><small>Pago único</small><strong>$9.990 CLP</strong><span>Acceso por 3 meses</span></div><div class="actions"><a class="primary" href="https://pay.hotmart.com/P106806251E" target="_blank" rel="noopener noreferrer">Comprar en Hotmart</a><a class="secondary" href="../?producto=kinecheck-recupera">Ver ficha completa</a></div></section></main><footer><p>KineCheck · Salud musculoesquelética</p></footer></body></html>
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      name="description"
+      content="KineCheck Recupera: aplicación web de seguimiento personal de síntomas, función, sueño, ejercicios y progreso, sin instalación."
+    />
+    <meta name="robots" content="index,follow,max-image-preview:large" />
+    <link
+      rel="canonical"
+      href="https://kinecheck.cl/productos/kinecheck-recupera/"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_CL" />
+    <meta property="og:site_name" content="KineCheck" />
+    <meta
+      property="og:title"
+      content="KineCheck Recupera | Seguimiento de recuperación"
+    />
+    <meta
+      property="og:description"
+      content="Registra cómo te has sentido, sigue tu plan y observa tu progreso. No diagnostica ni reemplaza la atención profesional."
+    />
+    <meta
+      property="og:url"
+      content="https://kinecheck.cl/productos/kinecheck-recupera/"
+    />
+    <title>KineCheck Recupera | Seguimiento de recuperación</title>
+    <link
+      rel="icon"
+      href="../../assets/kinecheck-mark.svg"
+      type="image/svg+xml"
+    />
+    <link rel="stylesheet" href="../../kinecheck/site-v5.css?v=6" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": "KineCheck Recupera",
+        "description": "Aplicación web de seguimiento personal de síntomas, función, sueño, ejercicios y progreso, sin instalación. No diagnostica ni prescribe.",
+        "brand": { "@type": "Brand", "name": "KineCheck" },
+        "offers": {
+          "@type": "Offer",
+          "price": "9990",
+          "priceCurrency": "CLP",
+          "url": "https://pay.hotmart.com/P106806251E",
+          "availability": "https://schema.org/InStock"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="../../"
+        ><img src="../../assets/kinecheck-mark.svg" alt="KineCheck" />
+        <div><strong>KineCheck</strong><small>RECUPERA</small></div></a
+      >
+      <nav>
+        <a href="../../recupera/">Recupera</a
+        ><a href="../../academy/">Ingresar</a>
+      </nav>
+    </header>
+    <main>
+      <section class="page-hero rec">
+        <span class="family-label"
+          >KINECHECK APPS · APLICACIÓN WEB · SIN INSTALACIÓN</span
+        >
+        <span class="eyebrow">KINECHECK RECUPERA</span>
+        <h1>Haz visible tu progreso.</h1>
+        <p>
+          Aplicación web de seguimiento personal para registrar síntomas,
+          función, sueño, ejercicios y evolución, sin instalación. KineCheck
+          Recupera no diagnostica, no prescribe tratamientos y no reemplaza una
+          atención profesional.
+        </p>
+        <div class="price">
+          <small>Pago único</small><strong>$9.990 CLP</strong
+          ><span>Acceso por 3 meses</span>
+        </div>
+        <div class="actions">
+          <a
+            class="primary"
+            href="https://pay.hotmart.com/P106806251E"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Comprar en Hotmart</a
+          ><a class="secondary" href="../?producto=kinecheck-recupera"
+            >Ver ficha completa</a
+          ><a class="secondary" href="../../muestras/#recupera"
+            >Ver demostración</a
+          >
+        </div>
+      </section>
+    </main>
+    <footer><p>KineCheck · Salud musculoesquelética</p></footer>
+  </body>
+</html>

--- a/productos/kinecheck-recupera/index.html
+++ b/productos/kinecheck-recupera/index.html
@@ -8,10 +8,7 @@
       content="KineCheck Recupera: aplicación web de seguimiento personal de síntomas, función, sueño, ejercicios y progreso, sin instalación."
     />
     <meta name="robots" content="index,follow,max-image-preview:large" />
-    <link
-      rel="canonical"
-      href="https://kinecheck.cl/productos/kinecheck-recupera/"
-    />
+    <link rel="canonical" href="https://kinecheck.cl/productos/kinecheck-recupera/">
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="es_CL" />
     <meta property="og:site_name" content="KineCheck" />

--- a/productos/product-clinico-reposition-v1.js
+++ b/productos/product-clinico-reposition-v1.js
@@ -47,11 +47,15 @@
   ];
   const faq = [
     ["¿Qué es KineCheck Clínico?", "Es un curso avanzado para profesionales. La guía digital es una herramienta complementaria para aplicar el método aprendido."],
+    ["¿Cómo se aprende dentro del curso?", "Cada módulo combina objetivos, lecciones breves, casos simulados, tareas de razonamiento, evidencia, preguntas de comprobación y retroalimentación explicada."],
     ["¿La guía reemplaza la ficha clínica de mi centro?", "No. Debes documentar la atención en el sistema oficial de tu institución y respetar sus exigencias legales, éticas y de seguridad."],
     ["¿Debo ingresar pacientes reales en la guía?", "No es necesario ni recomendado. Utiliza casos simulados, anonimizados o resúmenes sin datos identificables."],
     ["¿La misma compra incluye curso y guía?", "Sí. La licencia de KineCheck Clínico activa ambos componentes durante la vigencia informada."],
     ["¿El curso entrega diagnósticos o protocolos automáticos?", "No. Enseña a razonar, justificar decisiones, reconocer límites y reevaluar. La responsabilidad clínica permanece en el profesional."],
     ["¿Qué evidencia utiliza?", "Integra guías de alta calidad, OMS, marco IFOMPT y revisiones sobre seguridad, pruebas diagnósticas, dinamometría, resultados y educación del razonamiento clínico."],
+    ["¿Puedo revisar algo antes de comprar?", "Sí. La demostración pública incluye una experiencia clínica seleccionada y permite conocer el tipo de caso, pregunta y retroalimentación del curso."],
+    ["¿Qué soporte y actualizaciones incluye?", "El soporte cubre acceso, licencia, navegación, funcionamiento y consultas sobre el contenido. El objetivo de respuesta inicial es dentro de 2 días hábiles; las correcciones y mejoras quedan disponibles durante la vigencia activa."],
+    ["¿Necesito instalar una aplicación?", "No. El curso y la guía complementaria se utilizan desde un navegador moderno en computador, tablet o teléfono."],
   ];
 
   document.title = "KineCheck Clínico | Curso profesional y guía complementaria";

--- a/productos/product-experience-unification-v1.js
+++ b/productos/product-experience-unification-v1.js
@@ -51,9 +51,9 @@
 
   function studentRoute() {
     document.body.classList.add("kc-product-student");
-    setText("#product-type", "APRENDIZAJE GUIADO · 12 MESES");
+    setText("#product-type", "APLICACIÓN WEB FORMATIVA · SIN INSTALACIÓN");
     setText("#product-subtitle", "Tu primer paso para aprender evaluación y razonamiento clínico");
-    setText("#product-description", "Una experiencia guiada que te indica qué hacer primero, por qué hacerlo y qué revisar antes de avanzar a cursos clínicos más complejos.");
+    setText("#product-description", "Una aplicación web guiada que te indica qué hacer primero, por qué hacerlo y qué revisar antes de avanzar a cursos clínicos más complejos. Se usa desde el navegador, sin instalación.");
     setText("#story-copy", "Practica el proceso completo en un orden comprensible: historia, seguridad, observación, movimiento, medición, hipótesis y comunicación. La meta no es rellenar casillas, sino aprender a relacionar la información.");
     setText("#audience-copy", "Estudiantes de kinesiología que necesitan estructura para practicar evaluación clínica sin saltarse pasos importantes.");
     setHtml("#audience-pills", "<span>Estudiantes</span><span>Práctica inicial</span><span>Razonamiento guiado</span>");
@@ -80,10 +80,10 @@
   function patientExperience() {
     document.body.classList.add("kc-product-patient");
     setMetadata("KineCheck Recupera | Mi plan y mi avance", "KineCheck Recupera: revisa tu plan, registra cómo te sientes y observa tu avance con una experiencia simple.");
-    setText("#product-type", "MI RECUPERACIÓN · 3 MESES");
+    setText("#product-type", "APLICACIÓN WEB DE SEGUIMIENTO · SIN INSTALACIÓN");
     setHtml("#product-title", "KineCheck <em>Recupera</em>");
     setText("#product-subtitle", "Tu plan, tu registro y tu avance");
-    setText("#product-description", "Una herramienta simple para saber qué corresponde hacer hoy, registrar cómo te sientes y observar tu progreso. No necesitas conocimientos clínicos.");
+    setText("#product-description", "Una aplicación web simple para saber qué corresponde hacer hoy, registrar cómo te sientes y observar tu progreso. Se usa desde el navegador, sin instalación ni conocimientos clínicos.");
     setText("#breadcrumb-name", "Recupera");
     setText("#story-copy", "Abre Recupera, revisa tu plan y responde preguntas breves. La información te ayuda a seguir el proceso y a conversar mejor con el profesional que te acompaña.");
     setText("#audience-copy", "Personas que están realizando un plan de recuperación indicado o supervisado por un profesional.");
@@ -107,6 +107,7 @@
       <details><summary>¿Quién define mis ejercicios?</summary><p>Tu plan debe provenir del profesional que te evalúa o acompaña. Recupera ayuda a seguirlo; no prescribe ni diagnostica.</p></details>
       <details><summary>¿Qué hago si empeoro o aparece algo preocupante?</summary><p>Suspende lo que estés haciendo y contacta al profesional o al servicio de salud correspondiente. Recupera no es un servicio de urgencia.</p></details>
       <details><summary>¿Puedo compartir mi progreso?</summary><p>Puedes utilizar el resumen para conversar sobre tu evolución, evitando enviar información sensible por canales inseguros.</p></details>
+      <details><summary>¿Debo instalar una aplicación?</summary><p>No. Recupera se utiliza desde un navegador moderno en computador, tablet o teléfono.</p></details>
       <details><summary>¿Cuánto dura el acceso?</summary><p>La compra nueva incluye 3 meses desde la aprobación en Hotmart.</p></details>
     `);
 

--- a/productos/product-trust-v2.css
+++ b/productos/product-trust-v2.css
@@ -1,0 +1,273 @@
+[hidden] {
+  display: none !important;
+}
+
+.module-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.module-card {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.035);
+  overflow: hidden;
+}
+
+.module-card summary {
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 12px;
+  align-items: center;
+  min-height: 84px;
+  padding: 17px 19px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.module-card summary::-webkit-details-marker {
+  display: none;
+}
+
+.module-card summary::after {
+  content: "+";
+  position: absolute;
+  right: 18px;
+  color: var(--accent-soft);
+  font-size: 20px;
+}
+
+.module-card summary {
+  position: relative;
+  padding-right: 48px;
+}
+
+.module-card[open] summary {
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+.module-card[open] summary::after {
+  content: "−";
+}
+
+.module-card summary span {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent) 15%, rgba(255, 255, 255, 0.04));
+  color: var(--accent-soft);
+  font-size: 12px;
+  font-weight: 950;
+}
+
+.module-card summary strong {
+  line-height: 1.35;
+}
+
+.module-card > p {
+  margin: 0;
+  padding: 17px 20px 20px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.confidence-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 13px;
+}
+
+.author-panel,
+.method-panel,
+.sample-panel {
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: linear-gradient(
+    150deg,
+    rgba(14, 48, 57, 0.9),
+    rgba(5, 23, 30, 0.98)
+  );
+}
+
+.author-panel {
+  grid-column: span 2;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 17px;
+  align-items: start;
+  padding: 26px;
+}
+
+.author-mark {
+  display: grid;
+  place-items: center;
+  width: 64px;
+  height: 64px;
+  border-radius: 17px;
+  background: linear-gradient(135deg, var(--accent), #72cfff);
+  color: #032229;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+}
+
+.author-panel span,
+.method-panel > span {
+  color: var(--accent-soft);
+  font-size: 10px;
+  font-weight: 950;
+  letter-spacing: 0.13em;
+}
+
+.author-panel h3,
+.method-panel h3,
+.sample-panel h3 {
+  margin: 7px 0 8px;
+  font-size: 22px;
+  letter-spacing: -0.035em;
+}
+
+.author-panel p,
+.method-panel p,
+.sample-panel p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.method-panel {
+  padding: 25px;
+}
+
+.method-panel a {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  margin-top: 12px;
+  color: var(--accent-soft);
+  font-weight: 850;
+  text-decoration: none;
+}
+
+.sample-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(300px, 0.95fr);
+  gap: 20px;
+  margin-top: 15px;
+  padding: clamp(24px, 4vw, 42px);
+  background:
+    radial-gradient(
+      circle at 92% 10%,
+      color-mix(in srgb, var(--accent) 23%, transparent),
+      transparent 34%
+    ),
+    linear-gradient(150deg, rgba(14, 48, 57, 0.95), rgba(5, 23, 30, 0.99));
+}
+
+.sample-panel h3 {
+  font-size: clamp(27px, 3vw, 40px);
+}
+
+.sample-panel p + p {
+  margin-top: 12px;
+}
+
+.sample-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.sample-tags span {
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: #d9eceb;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.sample-question {
+  padding: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 18px;
+  background: rgba(1, 15, 20, 0.48);
+}
+
+.sample-question small {
+  color: var(--accent-soft);
+  font-weight: 950;
+  letter-spacing: 0.12em;
+}
+
+.sample-question > strong {
+  display: block;
+  margin: 9px 0 13px;
+}
+
+.sample-question ol {
+  display: grid;
+  gap: 8px;
+  margin: 0 0 18px;
+  padding: 0;
+  list-style: none;
+  counter-reset: sample;
+}
+
+.sample-question li {
+  counter-increment: sample;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  color: #c8dbda;
+  font-size: 13px;
+}
+
+.sample-question li::before {
+  content: counter(sample, upper-alpha) ". ";
+  color: var(--accent-soft);
+  font-weight: 900;
+}
+
+.sample-question li.correct {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: #effffc;
+}
+
+.sample-question .button {
+  width: 100%;
+}
+
+@media (max-width: 980px) {
+  .module-grid,
+  .sample-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .confidence-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 680px) {
+  .module-grid,
+  .confidence-grid,
+  .author-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .author-panel {
+    grid-column: auto;
+  }
+
+  .module-card summary {
+    min-height: 74px;
+    padding: 14px 44px 14px 14px;
+  }
+}

--- a/productos/product.js
+++ b/productos/product.js
@@ -6,43 +6,44 @@
   const PRODUCTS = Object.freeze({
     "kinecheck-clinico": {
       name: "KineCheck Clínico",
-      family: "KineCheck Apps",
+      family: "KineCheck Formación",
       shortName: "Clínico",
-      type: "Aplicación profesional",
+      type: "Curso profesional + guía complementaria",
       term: "12 meses",
       accent: "#18c7b7",
       accentSoft: "#77f1e5",
-      subtitle: "Registro kinésico profesional y razonamiento estructurado",
-      description: "Organiza la evaluación, los hallazgos, las hipótesis, los objetivos, la intervención y el seguimiento en un flujo clínico coherente. KineCheck Clínico facilita el registro y la síntesis sin reemplazar el juicio profesional.",
-      audience: "Kinesiólogos y profesionales que necesitan registrar, analizar y continuar casos musculoesqueléticos con mayor orden y claridad.",
+      subtitle: "Evaluación, seguridad y razonamiento musculoesquelético",
+      description: "Curso profesional avanzado para aprender a integrar historia, seguridad, examen, medición, hipótesis y reevaluación. Incluye una guía digital complementaria para aplicar el método sin reemplazar la ficha clínica institucional.",
+      audience: "Kinesiólogos y profesionales de rehabilitación musculoesquelética que buscan profundizar su evaluación y razonamiento clínico.",
       audiences: ["Kinesiólogos", "Profesionales musculoesqueléticos", "Docentes clínicos"],
       checkout: "https://pay.hotmart.com/L106791841D",
       outcomes: [
-        ["Evaluación organizada", "Estructura antecedentes, seguridad, examen físico, función y evolución."],
-        ["Razonamiento visible", "Relaciona hallazgos, hipótesis, prioridades y objetivos clínicos."],
-        ["Seguimiento continuo", "Permite retomar casos, observar cambios y mantener la información relevante."],
-        ["Síntesis profesional", "Genera una visión compacta del caso para revisar, comunicar o documentar."],
+        ["Razonamiento clínico explícito", "Conecta historia, seguridad, examen, medición, hipótesis y decisiones revisables."],
+        ["Evaluación segura", "Prioriza triage, banderas clínicas, deterioro neurológico y criterios de derivación."],
+        ["Medición defendible", "Estandariza movilidad, fuerza, desempeño y resultados informados por la persona."],
+        ["Integración biopsicosocial", "Relaciona función, participación, contexto, expectativas y factores modificadores."],
         ["Seguridad clínica", "Integra banderas, criterios de derivación y límites del manejo kinésico."],
-        ["Acceso multiplataforma", "Funciona desde computador, tablet y teléfono sin instalación."],
+        ["Aplicación mediante guía", "Utiliza la guía complementaria para revisar omisiones sin reemplazar la ficha institucional."],
       ],
       contents: [
-        ["Anamnesis y contexto", "Motivo de consulta, evolución, carga, sueño, antecedentes y objetivos de la persona."],
-        ["Seguridad y complejidad", "Banderas clínicas, irritabilidad, precauciones y necesidad de derivación."],
-        ["Examen físico", "Movimiento, fuerza, sensibilidad, función y pruebas pertinentes según el caso."],
-        ["Hipótesis y prioridades", "Organización del problema, factores contribuyentes y focos de intervención."],
-        ["Plan y seguimiento", "Objetivos, intervención, reevaluación y continuidad del proceso."],
+        ["Curso profesional central", "10 módulos, 30 experiencias clínicas, casos, comprobaciones y progreso guardado."],
+        ["Seguridad y triage", "Banderas clínicas, examen neurológico y marco cervical IFOMPT."],
+        ["Historia y contexto", "Síntomas, irritabilidad, factores psicosociales, metas y decisiones compartidas."],
+        ["Examen y medición", "Movimiento, fuerza, desempeño, examen neurológico, neurodinámica y pruebas especiales."],
+        ["Integración y seguimiento", "CIF, hipótesis, pronóstico, resultados, reevaluación y síntesis final."],
+        ["Guía digital complementaria", "Apoyo para revisar preguntas, hallazgos e hipótesis. No es una ficha clínica oficial ni un repositorio de pacientes."],
       ],
-      disclaimer: "Herramienta de apoyo al registro y razonamiento. No entrega diagnósticos automáticos ni sustituye la evaluación profesional.",
+      disclaimer: "Producto educativo para profesionales. La guía complementaria no reemplaza el registro clínico institucional, no debe utilizarse como repositorio de datos identificables y no sustituye el juicio profesional ni la derivación oportuna.",
       faq: [
-        ["¿Puede usarse con pacientes reales?", "Sí, siempre que registres información anonimizada y cumplas las normas éticas y legales aplicables."],
-        ["¿La aplicación toma decisiones por mí?", "No. Organiza información y facilita el análisis, pero la interpretación y las decisiones corresponden al profesional."],
+        ["¿Qué es KineCheck Clínico?", "Es un curso avanzado para profesionales. La guía digital es una herramienta complementaria para aplicar el método aprendido."],
+        ["¿La guía reemplaza la ficha clínica de mi centro?", "No. La atención debe documentarse en el sistema oficial de la institución y respetar sus exigencias legales, éticas y de seguridad."],
       ],
     },
     "kinecheck-estudiante": {
       name: "KineCheck Estudiante",
       family: "KineCheck Apps",
       shortName: "Estudiante",
-      type: "Aplicación formativa",
+      type: "Aplicación web formativa · sin instalación",
       term: "12 meses",
       accent: "#5c67d7",
       accentSoft: "#b7bcff",
@@ -76,7 +77,7 @@
       name: "KineCheck Recupera",
       family: "KineCheck Apps",
       shortName: "Recupera",
-      type: "Aplicación de seguimiento",
+      type: "Aplicación web de seguimiento · sin instalación",
       term: "3 meses",
       accent: "#31b779",
       accentSoft: "#9bf0c5",
@@ -288,6 +289,9 @@
   document.documentElement.style.setProperty("--accent", product.accent);
   document.documentElement.style.setProperty("--accent-soft", product.accentSoft);
   document.body.dataset.product = slug;
+  document.querySelectorAll("[data-clinico-only]").forEach((node) => {
+    node.hidden = slug !== "kinecheck-clinico";
+  });
   document.title = `${product.name} | KineCheck`;
   document.querySelector('meta[name="description"]')?.setAttribute("content", product.description);
   document.querySelector('meta[property="og:title"]')?.setAttribute("content", `${product.name} | KineCheck`);
@@ -300,6 +304,7 @@
   $("#product-family").textContent = product.family;
   $("#product-type").textContent = product.type;
   $("#product-term").textContent = product.term;
+  $("#fact-format").textContent = product.type;
   $("#product-title").innerHTML = product.name.replace(/(KineCheck|Comunicación|Evidencia|Traumatología|Más allá)/, "<em>$1</em>");
   $("#product-subtitle").textContent = product.subtitle;
   $("#product-description").textContent = product.description;
@@ -327,7 +332,7 @@
     ["¿Cómo ingreso después de comprar?", "Crea o abre tu cuenta en kinecheck.cl/academy utilizando exactamente el mismo correo asociado a la compra en Hotmart."],
     ["¿Cuándo comienza la vigencia?", `La vigencia de ${product.term} comienza cuando el pago queda aprobado. Las compras activas anteriores a la política vigente conservan sus condiciones aplicables.`],
     ["¿Puedo compartir mi acceso?", "No. La licencia es personal e intransferible. No compartas correo, contraseña, capturas ni contenidos protegidos."],
-    ["¿Funciona en celular?", "Sí. La plataforma está diseñada para computador, tablet y teléfono, aunque algunas tareas extensas son más cómodas en una pantalla mayor."],
+    ["¿Debo instalar una aplicación?", "No. KineCheck funciona desde un navegador moderno en computador, tablet o teléfono. Algunas tareas extensas son más cómodas en una pantalla mayor."],
   ];
   $("#faq-grid").innerHTML = list([...product.faq, ...commonFaq], ([question, answer]) => `
     <details><summary>${question}</summary><p>${answer}</p></details>

--- a/profesionales/index.html
+++ b/profesionales/index.html
@@ -1,1 +1,292 @@
-<!doctype html><html lang="es"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="description" content="KineCheck ayuda a profesionales a fortalecer la evaluación musculoesquelética, hacer explícito el razonamiento clínico y trabajar con mayor claridad y seguridad mediante formación aplicada."><meta property="og:type" content="website"><meta property="og:locale" content="es_CL"><meta property="og:site_name" content="KineCheck"><meta property="og:title" content="KineCheck para profesionales | Evaluación y razonamiento clínico"><meta property="og:description" content="Formación aplicada y herramientas complementarias para estructurar evaluación, seguridad y razonamiento musculoesquelético."><meta property="og:url" content="https://kinecheck.cl/profesionales/"><link rel="canonical" href="https://kinecheck.cl/profesionales/"><title>KineCheck para profesionales</title><link rel="icon" href="../assets/kinecheck-mark.svg" type="image/svg+xml"><link rel="stylesheet" href="../kinecheck/site-v5.css?v=3"><script src="../kinecheck/site-v5.js?v=2" defer></script></head><body><a class="skip-link" href="#contenido">Saltar al contenido</a><header class="site-header"><a class="brand" href="../"><img src="../assets/kinecheck-mark.svg" alt="KineCheck"><div><strong>KineCheck</strong><small>PROFESIONALES</small></div></a><button class="menu-button" data-menu-button aria-expanded="false" aria-label="Abrir menú" aria-controls="public-navigation">☰</button><nav id="public-navigation" data-public-nav aria-label="Navegación principal"><a href="#soluciones">Soluciones</a><a href="#beneficios">Beneficios</a><a href="#preguntas">Preguntas</a><a class="nav-button" href="../academy/">Ingresar</a></nav></header><main id="contenido"><section class="page-hero"><span class="eyebrow">PARA PROFESIONALES</span><h1>Evalúa con estructura. Razona con criterio. Comunica con claridad.</h1><p>Formación clínica aplicada para profundizar evaluación, seguridad, razonamiento y comunicación, acompañada de herramientas digitales complementarias.</p><div class="actions"><a class="primary" href="#soluciones">Ver soluciones</a><a class="secondary" href="../academy/">Ya tengo acceso</a></div></section><section id="beneficios" class="section alt"><div class="section-head"><span class="eyebrow">POR QUÉ KINECHECK</span><h2>Menos improvisación. Más claridad clínica.</h2></div><div class="feature-grid"><article class="feature"><h3>Evaluación estructurada</h3><p>Integra historia, seguridad, examen, función y reevaluación con una lógica explícita.</p></article><article class="feature"><h3>Razonamiento visible</h3><p>Relaciona información clínica, contexto y evidencia sin reducir la evaluación a pruebas aisladas.</p></article><article class="feature"><h3>Aplicación real</h3><p>Utiliza cursos, casos, checklists y guías complementarias pensadas para trasladar el aprendizaje a la práctica.</p></article></div></section><section id="soluciones" class="section"><div class="section-head"><span class="eyebrow">SOLUCIONES PROFESIONALES</span><h2>Empieza por tu necesidad principal.</h2></div><div class="product-grid"><article class="product featured"><span class="family-label">KINECHECK FORMACIÓN + GUÍA COMPLEMENTARIA</span><span class="tag">RECOMENDADO</span><h3>KineCheck Clínico</h3><p>Un curso profesional avanzado de evaluación, seguridad y razonamiento musculoesquelético. Incluye una guía digital complementaria para aplicar el método aprendido sin reemplazar la ficha clínica institucional.</p><div class="price"><small>Pago único</small><strong>$39.990 CLP</strong><span>Acceso por 12 meses</span></div><div class="actions"><a class="primary" href="https://pay.hotmart.com/L106791841D" target="_blank" rel="noopener noreferrer">Comprar KineCheck Clínico</a></div></article><article class="product"><span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span><span class="tag">COMUNICACIÓN</span><h3>Comunicación Clínica</h3><p>Escucha, empatía, validación y educación clínica.</p><div class="price"><small>Pago único</small><strong>$19.900 CLP</strong><span>Acceso por 12 meses</span></div><div class="actions"><a class="secondary" href="https://pay.hotmart.com/T106883983U" target="_blank" rel="noopener noreferrer">Comprar curso</a></div></article><article class="product"><span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span><span class="tag">EVALUACIÓN MSK</span><h3>Más allá del Dolor</h3><p>Evaluación musculoesquelética integral y razonamiento clínico crítico.</p><div class="price"><small>Pago único</small><strong>$39.990 CLP</strong><span>Acceso por 12 meses</span></div><div class="actions"><a class="secondary" href="https://pay.hotmart.com/W106888386Q" target="_blank" rel="noopener noreferrer">Comprar curso</a></div></article><article class="product"><span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span><span class="tag">EVIDENCIA</span><h3>Evidencia Aplicada</h3><p>Búsqueda, lectura crítica y aplicación a decisiones clínicas.</p><div class="price"><small>Pago único</small><strong>$29.990 CLP</strong><span>Acceso por 12 meses</span></div><div class="actions"><a class="secondary" href="https://pay.hotmart.com/F106921972I" target="_blank" rel="noopener noreferrer">Comprar curso</a></div></article><article class="product"><span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span><span class="tag">TRAUMATOLOGÍA</span><h3>Traumatología y Ortopedia Clínica</h3><p>Del mecanismo lesional a una decisión clínica más segura.</p><div class="price"><small>Pago único</small><strong>$35.900 CLP</strong><span>Acceso por 12 meses</span></div><div class="actions"><a class="secondary" href="https://pay.hotmart.com/B106913952R" target="_blank" rel="noopener noreferrer">Comprar curso</a></div></article><article class="product"><span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span><span class="tag">PRÓXIMAMENTE</span><h3>Banderas Clínicas</h3><p>Curso en preparación sobre identificación, interpretación y toma de decisiones ante señales de alerta en la evaluación musculoesquelética.</p></article><article class="product"><span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span><span class="tag">PRÓXIMAMENTE</span><h3>Dolor Lumbar</h3><p>Curso en preparación sobre evaluación, razonamiento clínico y abordaje del dolor lumbar con foco en decisiones claras y práctica basada en evidencia.</p></article></div></section><section id="preguntas" class="section alt"><div class="section-head"><span class="eyebrow">PREGUNTAS FRECUENTES</span><h2>Antes de comprar.</h2></div><div class="faq"><details><summary>¿KineCheck Clínico reemplaza el juicio profesional o la ficha clínica?</summary><p>No. Es un curso profesional con una guía digital complementaria. La documentación oficial debe mantenerse en el sistema institucional y las decisiones corresponden al profesional.</p></details><details><summary>¿Cómo se activa?</summary><p>Compra mediante Hotmart e ingresa con el mismo correo utilizado durante el pago.</p></details></div></section><section class="final-cta"><span class="eyebrow">KINECHECK PROFESIONAL</span><h2>Convierte tu proceso clínico en una estructura más clara.</h2><div class="actions" style="justify-content:center"><a class="primary" href="https://pay.hotmart.com/L106791841D" target="_blank" rel="noopener noreferrer">Comprar KineCheck Clínico</a><a class="secondary" href="../">Volver al inicio</a></div></section></main><footer><div class="brand"><img src="../assets/kinecheck-mark.svg" alt="KineCheck"><div><strong>KineCheck</strong><small>SALUD MUSCULOESQUELÉTICA</small></div></div><p>Soporte: <a href="mailto:soporte.kinecheck@gmail.com">soporte.kinecheck@gmail.com</a></p></footer></body></html>
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      name="description"
+      content="KineCheck ayuda a profesionales a fortalecer la evaluación musculoesquelética, hacer explícito el razonamiento clínico y trabajar con mayor claridad y seguridad mediante formación aplicada."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_CL" />
+    <meta property="og:site_name" content="KineCheck" />
+    <meta
+      property="og:title"
+      content="KineCheck para profesionales | Evaluación y razonamiento clínico"
+    />
+    <meta
+      property="og:description"
+      content="Formación aplicada y herramientas complementarias para estructurar evaluación, seguridad y razonamiento musculoesquelético."
+    />
+    <meta property="og:url" content="https://kinecheck.cl/profesionales/" />
+    <link rel="canonical" href="https://kinecheck.cl/profesionales/" />
+    <title>KineCheck para profesionales</title>
+    <link rel="icon" href="../assets/kinecheck-mark.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="../kinecheck/site-v5.css?v=3" />
+    <script src="../kinecheck/site-v5.js?v=2" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#contenido">Saltar al contenido</a>
+    <header class="site-header">
+      <a class="brand" href="../"
+        ><img src="../assets/kinecheck-mark.svg" alt="KineCheck" />
+        <div><strong>KineCheck</strong><small>PROFESIONALES</small></div></a
+      ><button
+        class="menu-button"
+        data-menu-button
+        aria-expanded="false"
+        aria-label="Abrir menú"
+        aria-controls="public-navigation"
+      >
+        ☰
+      </button>
+      <nav
+        id="public-navigation"
+        data-public-nav
+        aria-label="Navegación principal"
+      >
+        <a href="#soluciones">Soluciones</a><a href="#beneficios">Beneficios</a
+        ><a href="#preguntas">Preguntas</a
+        ><a class="nav-button" href="../academy/">Ingresar</a>
+      </nav>
+    </header>
+    <main id="contenido">
+      <section class="page-hero">
+        <span class="eyebrow">PARA PROFESIONALES</span>
+        <h1>
+          Evalúa con estructura. Razona con criterio. Comunica con claridad.
+        </h1>
+        <p>
+          Formación clínica aplicada para profundizar evaluación, seguridad,
+          razonamiento y comunicación, acompañada de herramientas digitales
+          complementarias.
+        </p>
+        <div class="actions">
+          <a class="primary" href="#soluciones">Ver soluciones</a
+          ><a class="secondary" href="../academy/">Ya tengo acceso</a>
+        </div>
+      </section>
+      <section id="beneficios" class="section alt">
+        <div class="section-head">
+          <span class="eyebrow">POR QUÉ KINECHECK</span>
+          <h2>Menos improvisación. Más claridad clínica.</h2>
+        </div>
+        <div class="feature-grid">
+          <article class="feature">
+            <h3>Evaluación estructurada</h3>
+            <p>
+              Integra historia, seguridad, examen, función y reevaluación con
+              una lógica explícita.
+            </p>
+          </article>
+          <article class="feature">
+            <h3>Razonamiento visible</h3>
+            <p>
+              Relaciona información clínica, contexto y evidencia sin reducir la
+              evaluación a pruebas aisladas.
+            </p>
+          </article>
+          <article class="feature">
+            <h3>Aplicación real</h3>
+            <p>
+              Utiliza cursos, casos, checklists y guías complementarias pensadas
+              para trasladar el aprendizaje a la práctica.
+            </p>
+          </article>
+        </div>
+      </section>
+      <section id="soluciones" class="section">
+        <div class="section-head">
+          <span class="eyebrow">SOLUCIONES PROFESIONALES</span>
+          <h2>Empieza por tu necesidad principal.</h2>
+        </div>
+        <div class="product-grid">
+          <article class="product featured">
+            <span class="family-label"
+              >KINECHECK FORMACIÓN + GUÍA COMPLEMENTARIA</span
+            ><span class="tag">RECOMENDADO</span>
+            <h3>KineCheck Clínico</h3>
+            <p>
+              Un curso profesional avanzado de evaluación, seguridad y
+              razonamiento musculoesquelético. Incluye una guía digital
+              complementaria para aplicar el método aprendido sin reemplazar la
+              ficha clínica institucional.
+            </p>
+            <div class="price">
+              <small>Pago único</small><strong>$39.990 CLP</strong
+              ><span>Acceso por 12 meses</span>
+            </div>
+            <div class="actions">
+              <a
+                class="primary"
+                href="https://pay.hotmart.com/L106791841D"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Comprar KineCheck Clínico</a
+              ><a
+                class="secondary"
+                href="../productos/?producto=kinecheck-clinico#temario"
+                >Ver temario y metodología</a
+              ><a class="secondary" href="../muestras/#clinico"
+                >Probar una muestra</a
+              >
+            </div>
+          </article>
+          <article class="product">
+            <span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span
+            ><span class="tag">COMUNICACIÓN</span>
+            <h3>Comunicación Clínica</h3>
+            <p>Escucha, empatía, validación y educación clínica.</p>
+            <div class="price">
+              <small>Pago único</small><strong>$19.900 CLP</strong
+              ><span>Acceso por 12 meses</span>
+            </div>
+            <div class="actions">
+              <a
+                class="secondary"
+                href="https://pay.hotmart.com/T106883983U"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Comprar curso</a
+              >
+            </div>
+          </article>
+          <article class="product">
+            <span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span
+            ><span class="tag">EVALUACIÓN MSK</span>
+            <h3>Más allá del Dolor</h3>
+            <p>
+              Evaluación musculoesquelética integral y razonamiento clínico
+              crítico.
+            </p>
+            <div class="price">
+              <small>Pago único</small><strong>$39.990 CLP</strong
+              ><span>Acceso por 12 meses</span>
+            </div>
+            <div class="actions">
+              <a
+                class="secondary"
+                href="https://pay.hotmart.com/W106888386Q"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Comprar curso</a
+              >
+            </div>
+          </article>
+          <article class="product">
+            <span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span
+            ><span class="tag">EVIDENCIA</span>
+            <h3>Evidencia Aplicada</h3>
+            <p>Búsqueda, lectura crítica y aplicación a decisiones clínicas.</p>
+            <div class="price">
+              <small>Pago único</small><strong>$29.990 CLP</strong
+              ><span>Acceso por 12 meses</span>
+            </div>
+            <div class="actions">
+              <a
+                class="secondary"
+                href="https://pay.hotmart.com/F106921972I"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Comprar curso</a
+              >
+            </div>
+          </article>
+          <article class="product">
+            <span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span
+            ><span class="tag">TRAUMATOLOGÍA</span>
+            <h3>Traumatología y Ortopedia Clínica</h3>
+            <p>Del mecanismo lesional a una decisión clínica más segura.</p>
+            <div class="price">
+              <small>Pago único</small><strong>$35.900 CLP</strong
+              ><span>Acceso por 12 meses</span>
+            </div>
+            <div class="actions">
+              <a
+                class="secondary"
+                href="https://pay.hotmart.com/B106913952R"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Comprar curso</a
+              >
+            </div>
+          </article>
+          <article class="product">
+            <span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span
+            ><span class="tag">PRÓXIMAMENTE</span>
+            <h3>Banderas Clínicas</h3>
+            <p>
+              Curso en preparación sobre identificación, interpretación y toma
+              de decisiones ante señales de alerta en la evaluación
+              musculoesquelética.
+            </p>
+          </article>
+          <article class="product">
+            <span class="family-label">KINECHECK FORMACIÓN · POR KINECHECK</span
+            ><span class="tag">PRÓXIMAMENTE</span>
+            <h3>Dolor Lumbar</h3>
+            <p>
+              Curso en preparación sobre evaluación, razonamiento clínico y
+              abordaje del dolor lumbar con foco en decisiones claras y práctica
+              basada en evidencia.
+            </p>
+          </article>
+        </div>
+      </section>
+      <section id="preguntas" class="section alt">
+        <div class="section-head">
+          <span class="eyebrow">PREGUNTAS FRECUENTES</span>
+          <h2>Antes de comprar.</h2>
+        </div>
+        <div class="faq">
+          <details>
+            <summary>
+              ¿KineCheck Clínico reemplaza el juicio profesional o la ficha
+              clínica?
+            </summary>
+            <p>
+              No. Es un curso profesional con una guía digital complementaria.
+              La documentación oficial debe mantenerse en el sistema
+              institucional y las decisiones corresponden al profesional.
+            </p>
+          </details>
+          <details>
+            <summary>¿Cómo se activa?</summary>
+            <p>
+              Compra mediante Hotmart e ingresa con el mismo correo utilizado
+              durante el pago.
+            </p>
+          </details>
+        </div>
+      </section>
+      <section class="final-cta">
+        <span class="eyebrow">KINECHECK PROFESIONAL</span>
+        <h2>Convierte tu proceso clínico en una estructura más clara.</h2>
+        <div class="actions" style="justify-content: center">
+          <a
+            class="primary"
+            href="https://pay.hotmart.com/L106791841D"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Comprar KineCheck Clínico</a
+          ><a class="secondary" href="../muestras/#clinico">Ver demostración</a
+          ><a class="secondary" href="../">Volver al inicio</a>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="brand">
+        <img src="../assets/kinecheck-mark.svg" alt="KineCheck" />
+        <div>
+          <strong>KineCheck</strong><small>SALUD MUSCULOESQUELÉTICA</small>
+        </div>
+      </div>
+      <p>
+        Soporte:
+        <a href="mailto:soporte.kinecheck@gmail.com"
+          >soporte.kinecheck@gmail.com</a
+        >
+      </p>
+    </footer>
+  </body>
+</html>

--- a/profesionales/index.html
+++ b/profesionales/index.html
@@ -106,12 +106,7 @@
               >KINECHECK FORMACIÓN + GUÍA COMPLEMENTARIA</span
             ><span class="tag">RECOMENDADO</span>
             <h3>KineCheck Clínico</h3>
-            <p>
-              Un curso profesional avanzado de evaluación, seguridad y
-              razonamiento musculoesquelético. Incluye una guía digital
-              complementaria para aplicar el método aprendido sin reemplazar la
-              ficha clínica institucional.
-            </p>
+            <p>Un curso profesional avanzado de evaluación, seguridad y razonamiento musculoesquelético. Incluye una guía digital complementaria para aplicar el método aprendido sin reemplazar la ficha clínica institucional.</p>
             <div class="price">
               <small>Pago único</small><strong>$39.990 CLP</strong
               ><span>Acceso por 12 meses</span>

--- a/recupera/index.html
+++ b/recupera/index.html
@@ -1,1 +1,224 @@
-<!doctype html><html lang="es"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="description" content="Sigue tu recuperación de forma simple: registra cómo te sientes, revisa tu plan y observa tu progreso. KineCheck Recupera no diagnostica ni reemplaza la atención profesional."><meta property="og:type" content="website"><meta property="og:locale" content="es_CL"><meta property="og:site_name" content="KineCheck"><meta property="og:title" content="KineCheck Recupera | Seguimiento simple de tu recuperación"><meta property="og:description" content="Sigue tu recuperación de forma simple: registra cómo te sientes, revisa tu plan y observa tu progreso. KineCheck Recupera no diagnostica ni reemplaza la atención profesional."><meta property="og:url" content="https://kinecheck.cl/recupera/"><link rel="canonical" href="https://kinecheck.cl/recupera/"><title>KineCheck Recupera</title><link rel="icon" href="../assets/kinecheck-mark.svg" type="image/svg+xml"><link rel="stylesheet" href="../kinecheck/site-v5.css?v=3"><script src="../kinecheck/site-v5.js?v=2" defer></script></head><body><a class="skip-link" href="#contenido">Saltar al contenido</a><header class="site-header"><a class="brand" href="../"><img src="../assets/kinecheck-mark.svg" alt="KineCheck"><div><strong>KineCheck</strong><small>RECUPERA</small></div></a><button class="menu-button" data-menu-button aria-expanded="false" aria-label="Abrir menú" aria-controls="public-navigation">☰</button><nav id="public-navigation" data-public-nav aria-label="Navegación principal"><a href="#como-ayuda">Cómo ayuda</a><a href="#incluye">Qué incluye</a><a href="#preguntas">Preguntas</a><a class="nav-button" href="../academy/">Ingresar</a></nav></header><main id="contenido"><section class="page-hero rec"><span class="family-label">KINECHECK APPS</span><span class="eyebrow" style="color:var(--gold)">PARA PERSONAS EN RECUPERACIÓN</span><h1>Entiende mejor cómo has estado y si realmente estás avanzando.</h1><p>Guarda cómo te sientes cada día, sigue tu plan y comparte un resumen más claro con tu profesional.</p><div class="actions"><a class="primary" href="https://pay.hotmart.com/P106806251E" target="_blank" rel="noopener noreferrer">Comprar KineCheck Recupera</a><a class="secondary" href="#como-ayuda">Conocer cómo funciona</a></div></section><section id="como-ayuda" class="section alt"><div class="section-head"><span class="eyebrow" style="color:var(--gold)">SIMPLE Y COTIDIANO</span><h2>Tu recuperación no se resume en “mejor” o “peor”.</h2></div><div class="feature-grid"><article class="feature"><h3>Guarda cómo te has sentido</h3><p>Registra dolor, función, sueño y otras señales relevantes.</p></article><article class="feature"><h3>Sigue tu plan</h3><p>Marca tus ejercicios y observa qué tan constante has sido.</p></article><article class="feature"><h3>Observa tu progreso</h3><p>Revisa tendencias y prepara una conversación más concreta con tu kinesiólogo.</p></article></div></section><section id="incluye" class="section"><div class="split"><div><span class="eyebrow" style="color:var(--gold)">QUÉ INCLUYE</span><h2>Una bitácora digital de tu proceso.</h2><p>No diagnostica ni reemplaza una evaluación profesional. Te ayuda a registrar y comunicar mejor lo que ocurre entre controles.</p><div class="price"><small>Pago único</small><strong>$9.990 CLP</strong><span>Acceso por 3 meses</span></div><div class="actions"><a class="primary" href="https://pay.hotmart.com/P106806251E" target="_blank" rel="noopener noreferrer">Comprar ahora</a></div></div><div class="card"><h3>Puedes:</h3><ul><li>Registrar síntomas y actividades.</li><li>Marcar ejercicios y cumplimiento.</li><li>Observar cambios en el tiempo.</li><li>Preparar un resumen para tu atención.</li><li>Acceder desde teléfono o computador.</li></ul></div></div></section><section class="section alt"><div class="split"><div><span class="eyebrow" style="color:var(--gold)">EJEMPLO DE USO</span><h2>En vez de intentar recordar toda la semana…</h2></div><div class="quote" style="border-left-color:var(--gold)"><p>“El dolor subió el martes, dormí peor dos noches y no pude hacer el ejercicio completo. Desde el viernes camino más y me cuesta menos levantarme.”</p></div></div></section><section id="preguntas" class="section"><div class="section-head"><span class="eyebrow" style="color:var(--gold)">PREGUNTAS FRECUENTES</span><h2>Uso responsable.</h2></div><div class="faq"><details><summary>¿Entrega un diagnóstico?</summary><p>No. No diagnostica, no prescribe tratamientos y no reemplaza una evaluación profesional.</p></details><details><summary>¿Qué hago si empeoro mucho?</summary><p>Contacta a tu profesional o busca atención de salud según la intensidad y características de tus síntomas.</p></details><details><summary>¿Cómo ingreso?</summary><p>Usa el mismo correo registrado en Hotmart. La activación puede solicitar el código de transacción.</p></details></div></section><section class="final-cta"><span class="eyebrow" style="color:var(--gold)">KINECHECK RECUPERA</span><h2>Haz visible tu progreso, un día a la vez.</h2><div class="actions" style="justify-content:center"><a class="primary" href="https://pay.hotmart.com/P106806251E" target="_blank" rel="noopener noreferrer">Comprar KineCheck Recupera</a><a class="secondary" href="../">Volver al inicio</a></div></section></main><footer><div class="brand"><img src="../assets/kinecheck-mark.svg" alt="KineCheck"><div><strong>KineCheck</strong><small>SALUD MUSCULOESQUELÉTICA</small></div></div><p>Soporte: <a href="mailto:soporte.kinecheck@gmail.com">soporte.kinecheck@gmail.com</a></p></footer></body></html>
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      name="description"
+      content="Sigue tu recuperación de forma simple: registra cómo te sientes, revisa tu plan y observa tu progreso. KineCheck Recupera no diagnostica ni reemplaza la atención profesional."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_CL" />
+    <meta property="og:site_name" content="KineCheck" />
+    <meta
+      property="og:title"
+      content="KineCheck Recupera | Seguimiento simple de tu recuperación"
+    />
+    <meta
+      property="og:description"
+      content="Sigue tu recuperación de forma simple: registra cómo te sientes, revisa tu plan y observa tu progreso. KineCheck Recupera no diagnostica ni reemplaza la atención profesional."
+    />
+    <meta property="og:url" content="https://kinecheck.cl/recupera/" />
+    <link rel="canonical" href="https://kinecheck.cl/recupera/" />
+    <title>KineCheck Recupera</title>
+    <link rel="icon" href="../assets/kinecheck-mark.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="../kinecheck/site-v5.css?v=3" />
+    <script src="../kinecheck/site-v5.js?v=2" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#contenido">Saltar al contenido</a>
+    <header class="site-header">
+      <a class="brand" href="../"
+        ><img src="../assets/kinecheck-mark.svg" alt="KineCheck" />
+        <div><strong>KineCheck</strong><small>RECUPERA</small></div></a
+      ><button
+        class="menu-button"
+        data-menu-button
+        aria-expanded="false"
+        aria-label="Abrir menú"
+        aria-controls="public-navigation"
+      >
+        ☰
+      </button>
+      <nav
+        id="public-navigation"
+        data-public-nav
+        aria-label="Navegación principal"
+      >
+        <a href="#como-ayuda">Cómo ayuda</a><a href="#incluye">Qué incluye</a
+        ><a href="#preguntas">Preguntas</a
+        ><a class="nav-button" href="../academy/">Ingresar</a>
+      </nav>
+    </header>
+    <main id="contenido">
+      <section class="page-hero rec">
+        <span class="family-label"
+          >KINECHECK APPS · APLICACIÓN WEB · SIN INSTALACIÓN</span
+        ><span class="eyebrow" style="color: var(--gold)"
+          >PARA PERSONAS EN RECUPERACIÓN</span
+        >
+        <h1>Entiende mejor cómo has estado y si realmente estás avanzando.</h1>
+        <p>
+          Guarda cómo te sientes cada día, sigue tu plan y comparte un resumen
+          más claro con tu profesional. Accede desde navegador, sin instalación.
+        </p>
+        <div class="actions">
+          <a
+            class="primary"
+            href="https://pay.hotmart.com/P106806251E"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Comprar KineCheck Recupera</a
+          ><a class="secondary" href="../muestras/#recupera"
+            >Probar una muestra</a
+          ><a class="secondary" href="#como-ayuda">Conocer cómo funciona</a>
+        </div>
+      </section>
+      <section id="como-ayuda" class="section alt">
+        <div class="section-head">
+          <span class="eyebrow" style="color: var(--gold)"
+            >SIMPLE Y COTIDIANO</span
+          >
+          <h2>Tu recuperación no se resume en “mejor” o “peor”.</h2>
+        </div>
+        <div class="feature-grid">
+          <article class="feature">
+            <h3>Guarda cómo te has sentido</h3>
+            <p>Registra dolor, función, sueño y otras señales relevantes.</p>
+          </article>
+          <article class="feature">
+            <h3>Sigue tu plan</h3>
+            <p>Marca tus ejercicios y observa qué tan constante has sido.</p>
+          </article>
+          <article class="feature">
+            <h3>Observa tu progreso</h3>
+            <p>
+              Revisa tendencias y prepara una conversación más concreta con tu
+              kinesiólogo.
+            </p>
+          </article>
+        </div>
+      </section>
+      <section id="incluye" class="section">
+        <div class="split">
+          <div>
+            <span class="eyebrow" style="color: var(--gold)">QUÉ INCLUYE</span>
+            <h2>Una bitácora digital de tu proceso.</h2>
+            <p>
+              No diagnostica ni reemplaza una evaluación profesional. Te ayuda a
+              registrar y comunicar mejor lo que ocurre entre controles.
+            </p>
+            <div class="price">
+              <small>Pago único</small><strong>$9.990 CLP</strong
+              ><span>Acceso por 3 meses</span>
+            </div>
+            <div class="actions">
+              <a
+                class="primary"
+                href="https://pay.hotmart.com/P106806251E"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Comprar ahora</a
+              >
+            </div>
+          </div>
+          <div class="card">
+            <h3>Puedes:</h3>
+            <ul>
+              <li>Registrar síntomas y actividades.</li>
+              <li>Marcar ejercicios y cumplimiento.</li>
+              <li>Observar cambios en el tiempo.</li>
+              <li>Preparar un resumen para tu atención.</li>
+              <li>Acceder desde teléfono o computador.</li>
+              <li>Usar la aplicación web sin instalar nada.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+      <section class="section alt">
+        <div class="split">
+          <div>
+            <span class="eyebrow" style="color: var(--gold)"
+              >EJEMPLO DE USO</span
+            >
+            <h2>En vez de intentar recordar toda la semana…</h2>
+          </div>
+          <div class="quote" style="border-left-color: var(--gold)">
+            <p>
+              “El dolor subió el martes, dormí peor dos noches y no pude hacer
+              el ejercicio completo. Desde el viernes camino más y me cuesta
+              menos levantarme.”
+            </p>
+          </div>
+        </div>
+      </section>
+      <section id="preguntas" class="section">
+        <div class="section-head">
+          <span class="eyebrow" style="color: var(--gold)"
+            >PREGUNTAS FRECUENTES</span
+          >
+          <h2>Uso responsable.</h2>
+        </div>
+        <div class="faq">
+          <details>
+            <summary>¿Entrega un diagnóstico?</summary>
+            <p>
+              No. No diagnostica, no prescribe tratamientos y no reemplaza una
+              evaluación profesional.
+            </p>
+          </details>
+          <details>
+            <summary>¿Qué hago si empeoro mucho?</summary>
+            <p>
+              Contacta a tu profesional o busca atención de salud según la
+              intensidad y características de tus síntomas.
+            </p>
+          </details>
+          <details>
+            <summary>¿Cómo ingreso?</summary>
+            <p>
+              Usa el mismo correo registrado en Hotmart. La activación puede
+              solicitar el código de transacción.
+            </p>
+          </details>
+          <details>
+            <summary>¿Debo descargarla desde una tienda?</summary>
+            <p>
+              No. Recupera es una aplicación web y se abre en un navegador
+              moderno.
+            </p>
+          </details>
+        </div>
+      </section>
+      <section class="final-cta">
+        <span class="eyebrow" style="color: var(--gold)"
+          >KINECHECK RECUPERA</span
+        >
+        <h2>Haz visible tu progreso, un día a la vez.</h2>
+        <div class="actions" style="justify-content: center">
+          <a
+            class="primary"
+            href="https://pay.hotmart.com/P106806251E"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Comprar KineCheck Recupera</a
+          ><a class="secondary" href="../">Volver al inicio</a>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="brand">
+        <img src="../assets/kinecheck-mark.svg" alt="KineCheck" />
+        <div>
+          <strong>KineCheck</strong><small>SALUD MUSCULOESQUELÉTICA</small>
+        </div>
+      </div>
+      <p>
+        Soporte:
+        <a href="mailto:soporte.kinecheck@gmail.com"
+          >soporte.kinecheck@gmail.com</a
+        >
+      </p>
+    </footer>
+  </body>
+</html>

--- a/scripts/qa-commercial.mjs
+++ b/scripts/qa-commercial.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 
 const baseUrl = String(process.env.BASE_URL || "https://kinecheck.cl").replace(/\/$/, "");
+const reportPath = String(process.env.QA_REPORT_PATH || "qa-commercial-report.json");
 const products = [
   ["kinecheck-clinico", "KineCheck Clínico", "https://pay.hotmart.com/L106791841D", 39990, "$39.990"],
   ["kinecheck-estudiante", "KineCheck Estudiante", "https://pay.hotmart.com/G106801166S", 14990, "$14.990"],
@@ -45,6 +46,7 @@ async function checkSource() {
   const betaPage = await read("beta/index.html");
   const supportPage = await read("soporte/index.html");
   const supportScript = await read("soporte/support.js");
+  const demosPage = await read("muestras/index.html");
   const adminPage = await read("admin/index.html");
   const adminScript = await read("admin/admin.js");
 
@@ -75,12 +77,16 @@ async function checkSource() {
 
   const trustSignals = home.includes("Precios visibles")
     && home.includes("Compra segura")
-    && home.includes("Conoce el precio antes de decidir.");
-  record("Public trust layer", trustSignals ? "PASS" : "FAIL", "visible-price, secure-purchase and price-before-decision signals must be present");
+    && home.includes("Conoce el precio antes de decidir.")
+    && home.includes('id="confianza"')
+    && home.includes("Emmanuel Zúñiga")
+    && home.includes("dentro de 2 días hábiles")
+    && home.includes("Abrir demostraciones");
+  record("Public trust layer", trustSignals ? "PASS" : "FAIL", "price, author, method, support and demonstration signals must be present");
   record(
-    "Retired creator section",
-    !/id="confianza"|CREADO POR EMMANUEL ZÚÑIGA/i.test(home) ? "PASS" : "FAIL",
-    "the creator profile intentionally removed from the current public home must not return as stale content",
+    "Verified creator and method",
+    /id="confianza"[\s\S]*Emmanuel Zúñiga[\s\S]*Metodología explícita/i.test(home) ? "PASS" : "FAIL",
+    "the public home must identify the creator and explain the learning method",
   );
   record(
     "No fabricated social proof",
@@ -114,7 +120,24 @@ async function checkSource() {
     && !productExperience.includes("20260806-final5");
   record("Product access route", cleanProductAccess ? "PASS" : "FAIL", "product pages must rewrite private access directly to /academy/ without retired version parameters");
 
-  record("Automated support source", supportPage.includes('id="support-form"') && supportScript.includes("support-request") ? "PASS" : "FAIL", "support portal must submit to diagnostic endpoint");
+  const clinicalArchitecture = productPage.includes('<span id="product-family">KINECHECK FORMACIÓN</span>')
+    && !productPage.includes('<span id="product-family">KINECHECK APPS</span>')
+    && productPage.split('class="module-card"').length - 1 === 10
+    && productPage.includes('id="metodologia"');
+  record("Clinical public architecture", clinicalArchitecture ? "PASS" : "FAIL", "Clinico must be Formation with 10 modules, authorship and method in the static fallback");
+
+  const webAppDelivery = students.includes("APLICACIÓN WEB · SIN INSTALACIÓN")
+    && recovery.includes("APLICACIÓN WEB · SIN INSTALACIÓN")
+    && product.includes("Aplicación web formativa · sin instalación")
+    && product.includes("Aplicación web de seguimiento · sin instalación");
+  record("Web app delivery clarity", webAppDelivery ? "PASS" : "FAIL", "Estudiante and Recupera must be browser-based web apps without installation");
+
+  const demosPresent = ["clinico", "estudiante", "recupera"].every((id) => demosPage.includes(`id="${id}"`))
+    && demosPage.includes("Sin guardar datos")
+    && !/localStorage|sessionStorage/.test(demosPage);
+  record("Public product demonstrations", demosPresent ? "PASS" : "FAIL", "three limited demonstrations must be available without account or persisted data");
+
+  record("Automated support source", supportPage.includes('id="support-form"') && supportPage.includes("dentro de 2 días hábiles") && supportScript.includes("support-request") ? "PASS" : "FAIL", "support portal must state its scope and response target and submit to diagnostic endpoint");
   record("Private automation source", adminPage.includes('id="admin-login"') && adminScript.includes("automation-status") && adminScript.includes("automation-control") ? "PASS" : "FAIL", "admin portal must use protected status and control endpoints");
   record("Beta privacy consent", betaPage.includes("consentPrivacy") && betaPage.includes("../legal/privacidad.html") ? "PASS" : "FAIL", "beta form must require privacy consent");
 }
@@ -152,7 +175,7 @@ async function checkCheckout(name, url) {
 }
 
 async function checkLive() {
-  await checkPage("Public home", "/?qa=commercial-current", ["PRODUCTOS PRINCIPALES", "$39.990 CLP", "$14.990 CLP", "$9.990 CLP", "Precios visibles", "Compra segura"]);
+  await checkPage("Public home", "/?qa=commercial-current", ["PRODUCTOS PRINCIPALES", "$39.990 CLP", "$14.990 CLP", "$9.990 CLP", "Precios visibles", "Compra segura", "Emmanuel Zúñiga"]);
   await checkPage("Professional profile", "/profesionales/?qa=commercial-current", ["KineCheck Clínico", "$35.900 CLP", "RECOMENDADO"]);
   await checkPage("Student profile", "/estudiantes/?qa=commercial-current", ["KineCheck Estudiante", "$49.900 CLP", "RECOMENDADO"]);
   await checkPage("Recovery profile", "/recupera/?qa=commercial-current", ["KineCheck Recupera", "$9.990 CLP", "Acceso por 3 meses"]);
@@ -163,6 +186,7 @@ async function checkLive() {
   await checkPage("Refunds", "/legal/reembolsos.html", ["Retracto y reembolsos", "Hotmart"]);
   await checkPage("External beta", "/beta/", ["PROGRAMA BETA", 'id="beta-form"']);
   await checkPage("Automated support", "/soporte/", ["DIAGNÓSTICO AUTOMÁTICO", 'id="support-form"']);
+  await checkPage("Public demonstrations", "/muestras/", ["MIRA ANTES DE COMPRAR", 'id="clinico"', 'id="estudiante"', 'id="recupera"']);
   await checkPage("Private automation portal", "/admin/", ["Centro de automatización", 'id="admin-login"']);
 
   for (const [slug, name, checkout] of products) {
@@ -181,7 +205,7 @@ const report = {
   results,
   note: "Automated certification does not replace end-to-end purchase, webhook, refund, chargeback and authenticated-license tests with controlled Hotmart transactions.",
 };
-await fs.writeFile("qa-commercial-report.json", JSON.stringify(report, null, 2));
+await fs.writeFile(reportPath, JSON.stringify(report, null, 2));
 
 if (failures > 0) {
   console.error(`Commercial QA failed with ${failures} blocking issue(s).`);

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -13,6 +13,7 @@
   <url><loc>https://kinecheck.cl/productos/evidencia-aplicada/</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://kinecheck.cl/productos/traumatologia-ortopedia-clinica/</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://kinecheck.cl/productos/pack-estudiante/</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://kinecheck.cl/muestras/</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://kinecheck.cl/ayuda/</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://kinecheck.cl/bienvenida/</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://kinecheck.cl/soporte/</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>

--- a/soporte/index.html
+++ b/soporte/index.html
@@ -80,7 +80,9 @@
           <li><b>3</b><span>Se intenta conciliar una compra activa desincronizada.</span></li>
           <li><b>4</b><span>Se crea un ticket con prioridad y diagnóstico inicial.</span></li>
         </ol>
+        <p><strong>Objetivo de respuesta inicial: dentro de 2 días hábiles.</strong> El soporte cubre acceso, licencias, navegación, funcionamiento y consultas sobre el contenido adquirido.</p>
         <p>Las solicitudes de privacidad reciben prioridad alta. Para urgencias de salud, utiliza los canales sanitarios correspondientes: KineCheck no presta atención de urgencia.</p>
+        <p>Mientras tu acceso esté activo, recibirás las correcciones y mejoras incorporadas al producto. Revisa también las <a href="../legal/reembolsos.html">condiciones de postventa y reembolsos</a>.</p>
       </aside>
     </section>
   </main>

--- a/tests/launch-readiness-public.spec.mjs
+++ b/tests/launch-readiness-public.spec.mjs
@@ -95,7 +95,8 @@ try {
     await noJsPage.goto(`${BASE}/productos/?qa=no-js-${Date.now()}`, { waitUntil: "domcontentloaded", timeout: 60000 });
     const noJsText = await pageText(noJsPage);
     assert.ok(noJsText.includes("KineCheck Clínico"), "sin JS: falta el producto clínico por defecto");
-    assert.ok(noJsText.includes("KINECHECK APPS"), "sin JS: falta familia del producto clínico");
+    assert.ok(noJsText.includes("KINECHECK FORMACIÓN"), "sin JS: falta familia correcta del producto clínico");
+    assert.ok(!noJsText.includes("KINECHECK APPS"), "sin JS: Clínico sigue clasificado como aplicación");
     assert.ok(noJsText.includes("12 meses desde la aprobación"), "sin JS: falta vigencia clínica");
     assert.ok(noJsText.includes("Kinesiólogos titulados"), "sin JS: falta público objetivo");
     assert.equal(await noJsPage.locator("[data-checkout]").first().getAttribute("href"), "https://pay.hotmart.com/L106791841D", "sin JS: checkout clínico incorrecto");
@@ -139,7 +140,13 @@ try {
     }
     assert.ok(homeText.includes("Precios visibles"), `${device}: falta compromiso de transparencia de precio`);
     assert.ok(homeText.includes("Compra segura"), `${device}: falta compromiso de compra segura`);
-    assert.equal(await page.locator("#confianza").count(), 0, `${device}: reapareció la sección de autor retirada del main vigente`);
+    assert.equal(await page.locator("#confianza").count(), 1, `${device}: falta la sección de autoría y confianza`);
+    assert.ok(homeText.includes("Emmanuel Zúñiga"), `${device}: falta autoría identificable`);
+    assert.ok(homeText.includes("dentro de 2 días hábiles"), `${device}: falta tiempo orientativo de soporte`);
+    assert.equal(await page.locator('a[href^="./muestras/"]').count(), 5, `${device}: faltan enlaces a demostraciones públicas`);
+    const appsFamilyText = await page.locator(".brand-family-card", { hasText: "KINECHECK APPS" }).innerText();
+    assert.ok(appsFamilyText.includes("KineCheck Estudiante") && appsFamilyText.includes("KineCheck Recupera"), `${device}: Apps no enumera Estudiante y Recupera`);
+    assert.ok(!appsFamilyText.includes("Clínico"), `${device}: KineCheck Clínico reapareció dentro de Apps`);
     for (const family of ["KINECHECK APPS", "KINECHECK FORMACIÓN", "KINECHECK PACKS"]) assert.ok(homeText.includes(family), `${device}: falta familia ${family}`);
     assert.ok(!homeText.includes("$59.900"), `${device}: aparece precio antiguo del pack`);
     assert.ok(!/Academy clásica|PLATAFORMA 5\.0/i.test(homeText), `${device}: aparecen experiencias retiradas`);
@@ -147,6 +154,23 @@ try {
     await assertCleanAcademyLinks(page, `${device}/portada`);
     await assertPublicMenu(page, `${device}/portada`, viewport.width <= 900);
     await checkOverflow(page, `${device}/portada`);
+
+    // Demostraciones: las tres muestras funcionan sin cuenta ni persistencia.
+    await openPublicPage(page, "/muestras/", device);
+    const demoText = await pageText(page);
+    assert.equal(await page.locator(".demo-section").count(), 3, `${device}/muestras: deben existir tres demostraciones`);
+    assert.ok(demoText.includes("Sin guardar datos") && demoText.includes("Sin instalación"), `${device}/muestras: faltan condiciones de la muestra`);
+    await page.locator('[data-clinical-quiz] input[value="2"]').check();
+    await page.locator('[data-clinical-quiz] button[type="submit"]').click();
+    assert.ok((await page.locator("[data-clinical-feedback]").innerText()).includes("Decisión defendible"), `${device}/muestras: la retroalimentación clínica no funciona`);
+    await page.locator('[data-student-step="3"]').click();
+    await page.locator("#student-reasoning").fill("Priorizaría seguridad y elegiría un examen que pueda cambiar la conducta.");
+    assert.ok(Number(await page.locator("[data-student-count]").innerText()) > 20, `${device}/muestras: el contador de razonamiento no responde`);
+    await page.locator('[data-recovery-range="pain"]').fill("7");
+    await page.locator("[data-build-summary]").click();
+    assert.ok((await page.locator("[data-daily-summary]").innerText()).includes("Molestia 7/10"), `${device}/muestras: el resumen de Recupera no responde`);
+    await assertOpenGraph(page, `${device}/muestras`);
+    await checkOverflow(page, `${device}/muestras`);
 
     // Profesionales: catálogo completo, precios y CTA honestos.
     await openPublicPage(page, "/profesionales/", device);
@@ -207,6 +231,9 @@ try {
     const defaultProductText = await pageText(page);
     assert.ok(defaultProductText.includes("KineCheck Clínico"), `${device}/productos: la ficha por defecto no se hidrató`);
     assert.equal(await page.locator("[data-checkout]").first().getAttribute("href"), "https://pay.hotmart.com/L106791841D", `${device}/productos: CTA por defecto inválido`);
+    assert.equal(await page.locator("#temario .module-card").count(), 10, `${device}/productos: el temario clínico no muestra 10 módulos`);
+    assert.equal(await page.locator("#metodologia").count(), 1, `${device}/productos: falta autoría y metodología`);
+    assert.ok(defaultProductText.includes("Emmanuel Zúñiga") && defaultProductText.includes("30 experiencias clínicas"), `${device}/productos: faltan credenciales o metodología clínica`);
     await assertOpenGraph(page, `${device}/productos`);
     await checkOverflow(page, `${device}/productos`);
 
@@ -218,6 +245,9 @@ try {
       const text = await pageText(page);
       assert.ok(text.includes(name), `${device}/${slug}: falta nombre del producto`);
       assert.equal((await page.locator("#product-family").textContent() || "").trim(), family, `${device}/${slug}: familia incorrecta`);
+      if (slug === "kinecheck-estudiante" || slug === "kinecheck-recupera") {
+        assert.ok(text.includes("sin instalación"), `${device}/${slug}: no se explica que es una aplicación web sin instalación`);
+      }
       assert.ok(text.includes(price), `${device}/${slug}: falta ${price}`);
       const checkout = page.locator("[data-checkout]").first();
       assert.equal(await checkout.getAttribute("href"), expectedCheckout, `${device}/${slug}: checkout inválido`);

--- a/tests/public-source-regression.test.mjs
+++ b/tests/public-source-regression.test.mjs
@@ -7,7 +7,7 @@ const count = (source, token) => source.split(token).length - 1;
 
 const PUBLIC_HTML_DIRECTORIES = [
   "profesionales", "estudiantes", "recupera", "productos", "legal",
-  "beta", "ayuda", "soporte", "bienvenida", "kinecheck",
+  "beta", "ayuda", "soporte", "bienvenida", "kinecheck", "muestras",
 ];
 
 const CANONICAL_ACCESS_PAGES = [
@@ -75,6 +75,10 @@ test("la portada conserva soporte, precios y accesos canónicos", async () => {
   for (const price of ["$39.990 CLP", "$14.990 CLP", "$9.990 CLP"]) assert.ok(home.includes(price));
   assertAccessiblePublicShell(home);
   assert.equal(count(home, 'class="icon" aria-hidden="true"'), 3);
+  assert.ok(home.includes('id="confianza"'));
+  assert.ok(home.includes("Emmanuel Zúñiga"));
+  assert.ok(home.includes("dentro de 2 días hábiles"));
+  assert.equal(count(home, "Ver muestra funcional"), 3);
 });
 
 test("ninguna superficie pública visible usa /platform/ ni CTAs vacíos", async () => {
@@ -112,16 +116,36 @@ test("la arquitectura oficial de marca está explícita y es consistente", async
   assert.ok(!professionals.includes("Registro kinésico profesional"));
 
   const students = await read("estudiantes/index.html");
-  assert.equal(count(students, "KINECHECK APPS"), 1);
+  assert.equal(count(students, "KINECHECK APPS"), 2);
   assert.equal(count(students, "KINECHECK PACKS"), 1);
   assert.equal(count(students, "KINECHECK FORMACIÓN · POR KINECHECK"), 2);
 
   const recovery = await read("recupera/index.html");
   assert.ok(recovery.includes("KINECHECK APPS"));
+  assert.ok(students.includes("APLICACIÓN WEB · SIN INSTALACIÓN"));
+  assert.ok(recovery.includes("APLICACIÓN WEB · SIN INSTALACIÓN"));
 
   const reposition = await read("productos/product-clinico-reposition-v1.js");
   assert.ok(reposition.includes('$("#product-family").textContent = "KINECHECK FORMACIÓN"'));
   assert.ok(reposition.includes("CURSO PROFESIONAL + GUÍA COMPLEMENTARIA"));
+
+  const productPage = await read("productos/index.html");
+  assert.ok(productPage.includes('<span id="product-family">KINECHECK FORMACIÓN</span>'));
+  assert.ok(!productPage.includes('<span id="product-family">KINECHECK APPS</span>'));
+  assert.equal(count(productPage, 'class="module-card"'), 10);
+  assert.ok(productPage.includes('id="metodologia"'));
+
+  const productData = await read("productos/product.js");
+  const clinicoBlock = productData.slice(productData.indexOf('"kinecheck-clinico"'), productData.indexOf('"kinecheck-estudiante"'));
+  assert.ok(clinicoBlock.includes('family: "KineCheck Formación"'));
+  assert.ok(clinicoBlock.includes('type: "Curso profesional + guía complementaria"'));
+  assert.ok(!clinicoBlock.includes("Aplicación profesional"));
+  assert.ok(productData.includes('type: "Aplicación web formativa · sin instalación"'));
+  assert.ok(productData.includes('type: "Aplicación web de seguimiento · sin instalación"'));
+
+  const productExperience = await read("productos/product-experience-unification-v1.js");
+  assert.ok(productExperience.includes("APLICACIÓN WEB FORMATIVA · SIN INSTALACIÓN"));
+  assert.ok(productExperience.includes("APLICACIÓN WEB DE SEGUIMIENTO · SIN INSTALACIÓN"));
 
   const brandArchitecture = await read("docs/brand-architecture.md");
   assert.match(brandArchitecture, /### KineCheck Apps[\s\S]*KineCheck Estudiante[\s\S]*KineCheck Recupera/);
@@ -184,11 +208,29 @@ test("Productos entrega un fallback clínico útil sin JavaScript", async () => 
   assertOpenGraph(page, "https://kinecheck.cl/productos/");
   assert.ok(page.includes('<link rel="canonical" href="https://kinecheck.cl/productos/">'));
   assert.ok(page.includes("KineCheck</em> Clínico"));
+  assert.ok(page.includes('<span id="product-family">KINECHECK FORMACIÓN</span>'));
+  assert.ok(!page.includes('<span id="product-family">KINECHECK APPS</span>'));
+  assert.equal(count(page, 'class="module-card"'), 10);
   assert.ok(page.includes("12 meses desde la aprobación"));
   assert.ok(page.includes('data-checkout href="https://pay.hotmart.com/L106791841D"'));
   assert.ok(page.includes('data-access href="../academy/"'));
   assert.ok(!page.includes("../platform/"));
   assert.match(headers, /\/productos\/\*[\s\S]*?Content-Security-Policy:\s*frame-ancestors 'none'/);
+});
+
+test("las demostraciones públicas son limitadas, funcionales y no guardan datos", async () => {
+  const page = await read("muestras/index.html");
+  const script = await read("muestras/demo-v1.js");
+  assertOpenGraph(page, "https://kinecheck.cl/muestras/");
+  assert.equal(count(page, 'class="demo-section'), 3);
+  for (const id of ["clinico", "estudiante", "recupera"]) assert.ok(page.includes(`id="${id}"`));
+  assert.ok(page.includes("Sin guardar datos"));
+  assert.ok(page.includes("SIN INSTALACIÓN"));
+  assert.doesNotMatch(page, /style=/);
+  assert.ok(script.includes("data-clinical-quiz"));
+  assert.ok(script.includes("data-student-step"));
+  assert.ok(script.includes("data-build-summary"));
+  assert.doesNotMatch(`${page}\n${script}`, /localStorage|sessionStorage|fetch\s*\(/);
 });
 
 test("la hidratación conserva ocho checkouts y acceso canónico", async () => {

--- a/tests/public-trust-browser.spec.mjs
+++ b/tests/public-trust-browser.spec.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { chromium, webkit } from "playwright";
+
+const BASE = String(process.env.BASE_URL || "http://127.0.0.1:4173").replace(
+  /\/$/,
+  "",
+);
+const AVAILABLE_BROWSERS = [
+  ["Chromium", chromium],
+  ["WebKit", webkit],
+];
+const requestedBrowsers = new Set(
+  String(process.env.BROWSERS || "chromium,webkit")
+    .toLowerCase()
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean),
+);
+const BROWSERS = AVAILABLE_BROWSERS.filter(([name]) =>
+  requestedBrowsers.has(name.toLowerCase()),
+);
+assert.ok(BROWSERS.length > 0, "BROWSERS debe incluir chromium o webkit");
+const VIEWPORTS = [
+  ["mobile", { width: 390, height: 844 }],
+  ["desktop", { width: 1440, height: 1000 }],
+];
+
+async function assertNoOverflow(page, label) {
+  const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  assert.ok(
+    scrollWidth <= clientWidth + 3,
+    `${label}: desbordamiento ${scrollWidth}/${clientWidth}`,
+  );
+}
+
+for (const [browserName, browserType] of BROWSERS) {
+  const browser = await browserType.launch({ headless: true });
+  try {
+    for (const [device, viewport] of VIEWPORTS) {
+      const context = await browser.newContext({
+        viewport,
+        locale: "es-CL",
+        timezoneId: "America/Santiago",
+      });
+      const page = await context.newPage();
+      const runtimeErrors = [];
+      page.on("pageerror", (error) => runtimeErrors.push(error.message));
+
+      await page.goto(`${BASE}/`, { waitUntil: "domcontentloaded" });
+      assert.equal(
+        await page.locator("#confianza").count(),
+        1,
+        `${browserName}/${device}: falta confianza`,
+      );
+      assert.equal(
+        await page.locator('a[href^="./muestras/"]').count(),
+        5,
+        `${browserName}/${device}: faltan CTA de muestra`,
+      );
+      const appsText = await page
+        .locator(".brand-family-card", { hasText: "KINECHECK APPS" })
+        .innerText();
+      assert.ok(
+        !appsText.includes("Clínico"),
+        `${browserName}/${device}: Clínico figura como app`,
+      );
+      await assertNoOverflow(page, `${browserName}/${device}/home`);
+
+      await page.goto(`${BASE}/productos/?producto=kinecheck-clinico`, {
+        waitUntil: "domcontentloaded",
+      });
+      await page.waitForSelector("#temario .module-card");
+      assert.equal(
+        await page.locator("#temario .module-card").count(),
+        10,
+        `${browserName}/${device}: temario incompleto`,
+      );
+      assert.equal(
+        (await page.locator("#product-family").innerText()).trim(),
+        "KINECHECK FORMACIÓN",
+        `${browserName}/${device}: familia clínica incorrecta`,
+      );
+      assert.ok(
+        (await page.locator("#metodologia").innerText()).includes(
+          "Emmanuel Zúñiga",
+        ),
+        `${browserName}/${device}: falta autoría`,
+      );
+      await assertNoOverflow(page, `${browserName}/${device}/clinico`);
+
+      await page.goto(`${BASE}/muestras/`, { waitUntil: "domcontentloaded" });
+      assert.equal(
+        await page.locator(".demo-section").count(),
+        3,
+        `${browserName}/${device}: muestras incompletas`,
+      );
+      await page.locator('[data-clinical-quiz] input[value="2"]').check();
+      await page.locator('[data-clinical-quiz] button[type="submit"]').click();
+      assert.ok(
+        (await page.locator("[data-clinical-feedback]").innerText()).includes(
+          "Decisión defendible",
+        ),
+        `${browserName}/${device}: quiz sin feedback`,
+      );
+      await page.locator('[data-student-step="3"]').click();
+      await page
+        .locator("#student-reasoning")
+        .fill(
+          "Priorizar seguridad y justificar qué hallazgo cambiaría la conducta.",
+        );
+      assert.ok(
+        Number(await page.locator("[data-student-count]").innerText()) > 20,
+        `${browserName}/${device}: contador inactivo`,
+      );
+      await page.locator("[data-build-summary]").click();
+      assert.ok(
+        (await page.locator("[data-daily-summary]").innerText()).includes(
+          "Resumen demostrativo",
+        ),
+        `${browserName}/${device}: resumen inactivo`,
+      );
+      await assertNoOverflow(page, `${browserName}/${device}/muestras`);
+
+      assert.deepEqual(
+        runtimeErrors,
+        [],
+        `${browserName}/${device}: errores de ejecución: ${runtimeErrors.join(" | ")}`,
+      );
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+console.log(
+  `Confianza pública validada en ${BROWSERS.map(([name]) => name).join(" y ")}, móvil y escritorio.`,
+);


### PR DESCRIPTION
## Resumen

- corrige la arquitectura visible: **Apps = Estudiante + Recupera**, **Formación = Clínico + cursos**, y **Packs** como familia independiente;
- comunica Estudiante y Recupera como aplicaciones web de navegador, sin instalación;
- presenta KineCheck Clínico como curso profesional con guía complementaria, temario público de 10 módulos, autoría, credenciales verificables, metodología y evidencia;
- añade demostraciones públicas funcionales de Clínico, Estudiante y Recupera, sin cuenta ni persistencia;
- hace visibles el alcance de soporte, el objetivo de respuesta inicial, las mejoras durante la vigencia y la postventa;
- amplía la regresión de fuente y el QA en Chromium/WebKit para móvil y escritorio.

## Validación ejecutada

- `node --test tests/public-source-regression.test.mjs` — 12/12
- `node tests/launch-readiness-public.spec.mjs` — móvil, tablet y escritorio; 8 productos y 3 perfiles
- `BROWSERS=chromium node tests/public-trust-browser.spec.mjs` — móvil y escritorio
- `node tests/product-overflow-diagnostic.mjs` — con y sin JavaScript
- `node scripts/qa-commercial.mjs` contra servidor local — sin bloqueos
- revisión visual de confianza, temario y muestras móviles

El workflow instala dependencias y ejecuta la prueba nueva tanto en Chromium como en WebKit.

## Alcance protegido

No cambia lógica de SSO/autenticación, dominios de aplicaciones, licencias, compras, webhooks, usuarios, Supabase, secretos ni flujos de Hotmart. El ajuste dentro de Academy se limita a la taxonomía visible de su catálogo.