### PR TITLE
Corrige bloqueo de scroll e interacción en Academy

### DIFF
--- a/academy/academy-brand-identity.js
+++ b/academy/academy-brand-identity.js
@@ -93,7 +93,7 @@
 
   loadScript("./mi-kinecheck-v1.js", "data-mi-kinecheck", "20260809-directnav2");
   loadScript("./mi-kinecheck-card-copy-v1.js", "data-mi-kinecheck-card-copy", "20260806-unified1");
-  loadScript("./mi-kinecheck-simplify-v2.js", "data-mi-kinecheck-simplify-v2", "20260809-directnav2");
+  loadScript("./mi-kinecheck-simplify-v2.js", "data-mi-kinecheck-simplify-v2", "20260810-interactionfix1");
   loadScript("./academy-clinico-course-v1.js", "data-kc-clinico-course", "20260806-final5");
 
   if (document.readyState === "loading") {

--- a/academy/academy-learning-path-v4.js
+++ b/academy/academy-learning-path-v4.js
@@ -392,6 +392,17 @@
   function openModal() {
     const modal = $("#kc-stage-modal");
     if (!modal) return;
+
+    // Mi KineCheck infiere el perfil desde los productos activos y oculta este
+    // selector legado. No debe abrirse en segundo plano: además de quedar
+    // invisible, su clase de modal bloqueaba el desplazamiento de toda Academy.
+    if (window.__MI_KINECHECK_SIMPLIFY_V2__ === true) {
+      closeModal();
+      return;
+    }
+
+    modal.removeAttribute("inert");
+    modal.removeAttribute("aria-hidden");
     const suggested = inferStage();
     const suggestedButton = $("#kc-stage-suggested");
     if (suggestedButton) {
@@ -404,8 +415,19 @@
 
   function closeModal() {
     const modal = $("#kc-stage-modal");
-    if (modal) modal.hidden = true;
+    if (modal && !modal.hidden) modal.hidden = true;
     document.body.classList.remove("kc-stage-modal-open");
+  }
+
+  function scheduleStageChooser() {
+    if (readSavedStage() || window.__MI_KINECHECK_SIMPLIFY_V2__ === true) {
+      closeModal();
+      return;
+    }
+
+    window.setTimeout(() => {
+      if (!readSavedStage()) openModal();
+    }, 350);
   }
 
   function selectStage(stage, notify = true) {
@@ -465,7 +487,7 @@
         if (!dashboard.hidden) {
           activeStage = readSavedStage() || inferStage();
           renderStage();
-          if (!readSavedStage()) window.setTimeout(openModal, 350);
+          scheduleStageChooser();
         }
       }).observe(dashboard, { attributes: true, attributeFilter: ["hidden"] });
     }
@@ -477,7 +499,7 @@
     observePlatform();
     activeStage = readSavedStage() || inferStage();
     renderStage();
-    if (!$("#dashboard-view")?.hidden && !readSavedStage()) window.setTimeout(openModal, 350);
+    if (!$("#dashboard-view")?.hidden) scheduleStageChooser();
   }
 
   if (document.readyState === "loading") {

--- a/academy/academy-reviews.js
+++ b/academy/academy-reviews.js
@@ -25,14 +25,14 @@
     if (!document.querySelector('link[data-kinecheck-learning-path]')) {
       const stylesheet = document.createElement("link");
       stylesheet.rel = "stylesheet";
-      stylesheet.href = "./academy-learning-path-v4.css?v=20260731-color2";
+      stylesheet.href = "./academy-learning-path-v4.css?v=20260810-interactionfix1";
       stylesheet.dataset.kinecheckLearningPath = "styles";
       document.head.appendChild(stylesheet);
     }
 
     if (!document.querySelector('script[data-kinecheck-learning-path]')) {
       const script = document.createElement("script");
-      script.src = "./academy-learning-path-v4.js?v=20260803-stable2";
+      script.src = "./academy-learning-path-v4.js?v=20260810-interactionfix1";
       script.dataset.kinecheckLearningPath = "script";
       script.defer = true;
       document.head.appendChild(script);

--- a/academy/index.html
+++ b/academy/index.html
@@ -19,7 +19,7 @@
   <script src="../watermark.js?v=20260730b" defer></script>
   <script src="./academy-v39.js?v=20260803-sessionfix2" defer></script>
   <script src="./academy-evidence-alerts.js?v=20260803-stable2" data-academy-evidence="script" defer></script>
-  <script src="./academy-reviews.js?v=20260803-sessionfix2" defer></script>
+  <script src="./academy-reviews.js?v=20260810-interactionfix1" defer></script>
   <script src="./academy-kinecheck-v4.js?v=20260803-stable2" defer></script>
 </head>
 <body data-kc-view="inicio">

--- a/academy/mi-kinecheck-simplify-v2.js
+++ b/academy/mi-kinecheck-simplify-v2.js
@@ -4,7 +4,7 @@
   if (window.__MI_KINECHECK_SIMPLIFY_V2__) return;
   window.__MI_KINECHECK_SIMPLIFY_V2__ = true;
 
-  const VERSION = "20260809-directnav2";
+  const VERSION = "20260810-interactionfix1";
   const STUDENT_ORDER = [
     "kinecheck-estudiante",
     "mas-alla-del-dolor",
@@ -83,7 +83,26 @@
     document.body.classList.remove("mi-kc-focused-student", "mi-kc-focused-patient");
   }
 
+  function releaseStaleInteractionLocks() {
+    const stageModal = document.querySelector("#kc-stage-modal");
+    if (stageModal) {
+      if (!stageModal.hidden) stageModal.hidden = true;
+      if (stageModal.getAttribute("aria-hidden") !== "true") stageModal.setAttribute("aria-hidden", "true");
+      if (!stageModal.hasAttribute("inert")) stageModal.setAttribute("inert", "");
+    }
+
+    // Recupera sesiones que quedaron congeladas por el selector legado oculto.
+    document.body.classList.remove("kc-stage-modal-open");
+
+    // Una evaluación cerrada tampoco debe conservar su bloqueo de scroll al
+    // volver desde el historial o restaurar una pestaña.
+    const reviewModal = document.querySelector("#review-modal");
+    if (!reviewModal || reviewModal.hidden) document.body.classList.remove("review-open");
+  }
+
   function removeStageChooser() {
+    releaseStaleInteractionLocks();
+
     hideAll("#kc-learning-path,#kc-profile-stage,#kc-sidebar-stage,#kc-topbar-stage,#kc-stage-modal", true);
     hideAll("#kc-change-stage,#kc-profile-stage-change,[data-kc-stage-choice],#kc-stage-suggested", true);
     document.documentElement.classList.add("mi-kc-stage-inferred");
@@ -230,6 +249,11 @@
 
   if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", schedule, { once: true });
   else schedule();
+
+  window.addEventListener("pageshow", () => {
+    releaseStaleInteractionLocks();
+    schedule();
+  });
 
   new MutationObserver(schedule).observe(document.documentElement, {
     childList: true,

--- a/tests/live-academy-runtime.spec.mjs
+++ b/tests/live-academy-runtime.spec.mjs
@@ -193,3 +193,90 @@ test("navegación móvil real y botones nativos conservan eventos de puntero", a
   await expect(page.locator("#academy-sidebar")).toHaveClass(/open/);
   await expect(menu).toHaveAttribute("aria-expanded", "true");
 });
+
+test("Academy no conserva overlays invisibles ni bloquea el scroll o los controles", async ({ page }) => {
+  await page.setViewportSize({ width: 1867, height: 976 });
+
+  await page.addInitScript(() => {
+    const session = {
+      access_token: "qa-owner-access-token-with-safe-runtime-length",
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      expires_in: 3600,
+      token_type: "bearer",
+      user: {
+        id: "qa-owner-user",
+        email: "emmanuelkine@gmail.com",
+      },
+    };
+    localStorage.setItem("kinecheck_secure_session_v1", JSON.stringify(session));
+    localStorage.removeItem("kinecheck_learning_stage_v1:emmanuelkine@gmail.com");
+  });
+
+  await page.route("**/auth/v1/user", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json; charset=utf-8",
+      body: JSON.stringify({
+        id: "qa-owner-user",
+        email: "emmanuelkine@gmail.com",
+        created_at: "2026-01-01T00:00:00.000Z",
+      }),
+    });
+  });
+  await page.route("**/functions/v1/metric-event", async (route) => {
+    await route.fulfill({ status: 202, contentType: "application/json", body: '{"ok":true}' });
+  });
+
+  await openAcademy(page, "scroll-and-controls");
+  await expect(page.locator("#dashboard-view")).toBeVisible();
+  await expect(page.locator("#course-grid .course-card")).toHaveCount(9);
+  await page.locator('.topbar-nav [data-kc-view-link="biblioteca"]').click();
+  await expect(page.locator("body")).toHaveAttribute("data-kc-view", "biblioteca");
+
+  // El selector legado intentaba abrirse 350 ms después del dashboard.
+  await page.waitForTimeout(900);
+
+  const interactionState = await page.evaluate(() => {
+    const modal = document.querySelector("#kc-stage-modal");
+    return {
+      bodyClass: document.body.className,
+      bodyOverflow: getComputedStyle(document.body).overflow,
+      documentOverflow: getComputedStyle(document.documentElement).overflow,
+      modalHidden: modal?.hidden ?? true,
+      modalDisplay: modal ? getComputedStyle(modal).display : "missing",
+      scrollHeight: document.documentElement.scrollHeight,
+      viewportHeight: window.innerHeight,
+    };
+  });
+
+  expect(interactionState.bodyClass).not.toContain("kc-stage-modal-open");
+  expect(interactionState.bodyOverflow).not.toBe("hidden");
+  expect(interactionState.documentOverflow).not.toBe("hidden");
+  expect(interactionState.modalHidden || interactionState.modalDisplay === "none").toBeTruthy();
+  expect(interactionState.scrollHeight).toBeGreaterThan(interactionState.viewportHeight);
+
+  await page.evaluate(() => window.scrollTo(0, 700));
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+
+  for (const view of ["biblioteca", "herramientas", "perfil", "inicio"]) {
+    await page.locator(`.topbar-nav [data-kc-view-link="${view}"]`).click();
+    await expect(page.locator("body")).toHaveAttribute("data-kc-view", view);
+  }
+
+  await page.locator("#support-launcher").click();
+  await expect(page.locator("#support-panel")).toBeVisible();
+  await page.locator("[data-support-close]").click();
+  await expect(page.locator("#support-panel")).toBeHidden();
+
+  // También repara una pestaña restaurada por el navegador con locks antiguos.
+  await page.evaluate(() => {
+    document.body.classList.add("kc-stage-modal-open", "review-open");
+    const stageModal = document.querySelector("#kc-stage-modal");
+    const reviewModal = document.querySelector("#review-modal");
+    if (stageModal) stageModal.hidden = true;
+    if (reviewModal) reviewModal.hidden = true;
+    window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true }));
+  });
+  await expect.poll(() => page.evaluate(() => document.body.className)).not.toContain("modal-open");
+  await expect.poll(() => page.evaluate(() => document.body.className)).not.toContain("review-open");
+});


### PR DESCRIPTION
## Resumen

Corrige el bloqueo total de desplazamiento e interacción observado en **Mi KineCheck > Mis productos**.

## Causa raíz

El selector legado de etapa se abría automáticamente 350 ms después de cargar el panel. La experiencia actual lo ocultaba, pero quedaba activa la clase `kc-stage-modal-open`, que aplicaba `overflow: hidden` al documento. El resultado era una ventana invisible que congelaba la página y volvía inaccesibles los controles inferiores.

## Cambios

- impide que el selector legado se abra bajo la experiencia simplificada actual;
- elimina inmediatamente locks huérfanos de etapa y de reseñas cerradas;
- recupera pestañas restauradas desde el historial o BFCache;
- mantiene el modal legado funcional cuando la experiencia simplificada no está activa;
- actualiza las versiones de los módulos afectados para evitar activos obsoletos;
- añade una regresión real a 1867×976 que reproduce la captura, verifica scroll, navegación, soporte y recuperación de overlays invisibles.

## Validación

- reproducción previa confirmada: `kc-stage-modal-open` + `overflow: hidden`;
- 15/15 pruebas de navegador en Chromium;
- 3/3 perfiles de Mi KineCheck;
- 80/80 controles de acceso del ecosistema;
- healthcheck end-to-end: 0 fallos y 0 advertencias;
- CI ejecutará los mismos gates en Chromium y WebKit.

## Alcance protegido

No modifica SSO, licencias, compras, Hotmart, usuarios, Supabase, secretos, permisos ni destinos de productos.