### PR TITLE
Consolida el runtime de Academy y elimina el bloqueo intermitente

### DIFF
--- a/.github/workflows/validate-academy-evidence.yml
+++ b/.github/workflows/validate-academy-evidence.yml
@@ -81,8 +81,9 @@ jobs:
       - name: Confirmar conexión y versión del módulo
         run: |
           grep -Eq 'academy-reviews\.js\?v=[A-Za-z0-9._-]+' academy/index.html
-          grep -q 'academy-evidence-alerts.css' academy/academy-reviews.js
-          grep -q 'academy-evidence-alerts.js' academy/academy-reviews.js
+          grep -Eq 'academy-evidence-alerts\.css\?v=[A-Za-z0-9._-]+' academy/index.html
+          grep -Eq 'academy-evidence-alerts\.js\?v=[A-Za-z0-9._-]+' academy/index.html
+          ! grep -q 'createElement("script")' academy/academy-reviews.js
           grep -q 'evidence-alerts.json' academy/academy-evidence-alerts.js
           grep -q 'evidencia-semanal' academy/academy-evidence-alerts.js
           grep -q 'watchSessionActivation' academy/academy-evidence-alerts.js

--- a/.github/workflows/validate-recommended-buttons.yml
+++ b/.github/workflows/validate-recommended-buttons.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     paths:
       - 'metrics-v1.js'
+      - 'watermark.js'
+      - 'academy/index.html'
+      - 'academy/academy-bootstrap-v28.js'
+      - 'academy/academy-reviews.js'
       - 'academy/academy-open-v6.js'
       - 'academy/academy-owned-native-bridge-v1.js'
       - 'academy/academy-recommended-buttons-fix.js'
@@ -33,6 +37,10 @@ on:
     branches: [main]
     paths:
       - 'metrics-v1.js'
+      - 'watermark.js'
+      - 'academy/index.html'
+      - 'academy/academy-bootstrap-v28.js'
+      - 'academy/academy-reviews.js'
       - 'academy/academy-open-v6.js'
       - 'academy/academy-owned-native-bridge-v1.js'
       - 'academy/academy-recommended-buttons-fix.js'

--- a/.github/workflows/validate-unified-experience.yml
+++ b/.github/workflows/validate-unified-experience.yml
@@ -4,11 +4,15 @@ on:
   pull_request:
     paths:
       - "home.js"
+      - "watermark.js"
       - "home-experience-unification-v1.js"
       - "home-experience-unification-v1.css"
       - "productos/product-clinico-reposition-v1.js"
       - "productos/product-experience-unification-v1.js"
       - "productos/product-experience-unification-v1.css"
+      - "academy/index.html"
+      - "academy/academy-bootstrap-v28.js"
+      - "academy/academy-reviews.js"
       - "academy/academy-owned-native-bridge-v1.js"
       - "academy/academy-brand-identity.js"
       - "academy/mi-kinecheck-v1.js"
@@ -25,11 +29,15 @@ on:
     branches: [main]
     paths:
       - "home.js"
+      - "watermark.js"
       - "home-experience-unification-v1.js"
       - "home-experience-unification-v1.css"
       - "productos/product-clinico-reposition-v1.js"
       - "productos/product-experience-unification-v1.js"
       - "productos/product-experience-unification-v1.css"
+      - "academy/index.html"
+      - "academy/academy-bootstrap-v28.js"
+      - "academy/academy-reviews.js"
       - "academy/academy-owned-native-bridge-v1.js"
       - "academy/academy-brand-identity.js"
       - "academy/mi-kinecheck-v1.js"
@@ -64,9 +72,12 @@ jobs:
       - name: Validar sintaxis
         run: |
           node --check home.js
+          node --check watermark.js
           node --check home-experience-unification-v1.js
           node --check productos/product-clinico-reposition-v1.js
           node --check productos/product-experience-unification-v1.js
+          node --check academy/academy-bootstrap-v28.js
+          node --check academy/academy-reviews.js
           node --check academy/academy-brand-identity.js
           node --check academy/mi-kinecheck-v1.js
           node --check academy/mi-kinecheck-card-copy-v1.js
@@ -77,10 +88,17 @@ jobs:
 
       - name: Confirmar una sola puerta visible
         run: |
-          grep -q 'home-experience-unification-v1.js' home.js
-          grep -q 'mi-kinecheck-v1.js' academy/academy-brand-identity.js
-          grep -q 'mi-kinecheck-card-copy-v1.js' academy/academy-brand-identity.js
-          grep -q 'mi-kinecheck-simplify-v2.js' academy/academy-brand-identity.js
+          grep -q 'kinecheck/site-v5.js' index.html
+          ! grep -Eq 'home\.js|home-core-20260806\.js|home-commercial-proof-v1\.js|home-experience-unification-v1\.js' index.html
+          grep -q 'academy-open-v6.js' academy/index.html
+          grep -q 'academy-owned-native-bridge-v1.js' academy/index.html
+          grep -q 'mi-kinecheck-v1.js' academy/index.html
+          grep -q 'mi-kinecheck-card-copy-v1.js' academy/index.html
+          grep -q 'mi-kinecheck-simplify-v2.js' academy/index.html
+          ! grep -q 'academy-learning-path-v4.js' academy/index.html
+          ! grep -q 'createElement("script")' academy/academy-bootstrap-v28.js
+          ! grep -q 'createElement("script")' academy/academy-reviews.js
+          ! grep -q 'createElement("script")' academy/academy-brand-identity.js
           grep -q 'product-experience-unification-v1.js' productos/product-clinico-reposition-v1.js
           grep -q 'redirect-to-mi-kinecheck-v1.js' platform/index.html
           grep -q 'Abriendo Mi KineCheck' platform/index.html

--- a/academy/academy-bootstrap-v28.js
+++ b/academy/academy-bootstrap-v28.js
@@ -343,21 +343,3 @@ window.KINECHECK_ACADEMY_CONFIG = Object.freeze({
     return fetchWithTimeout(input, init);
   };
 })();
-
-(() => {
-  if (document.querySelector('script[data-kc-brand-identity]')) return;
-  const script = document.createElement("script");
-  script.src = "./academy-brand-identity.js?v=20260809-private1";
-  script.async = false;
-  script.dataset.kcBrandIdentity = "true";
-  document.head.appendChild(script);
-})();
-
-(() => {
-  if (document.querySelector('script[data-kc-access-recovery]')) return;
-  const script = document.createElement("script");
-  script.src = "./academy-access-recovery-v1.js?v=20260803-accessfix1";
-  script.defer = true;
-  script.dataset.kcAccessRecovery = "true";
-  document.head.appendChild(script);
-})();

--- a/academy/academy-brand-identity.js
+++ b/academy/academy-brand-identity.js
@@ -9,15 +9,6 @@
     if (element && element.textContent !== value) element.textContent = value;
   }
 
-  function loadScript(path, marker, version) {
-    if (document.querySelector(`script[${marker}]`)) return;
-    const script = document.createElement("script");
-    script.src = `${path}?v=${version}`;
-    script.async = false;
-    script.setAttribute(marker, "true");
-    document.head.appendChild(script);
-  }
-
   function applyIdentity() {
     document.title = BRAND_NAME;
 
@@ -81,20 +72,6 @@
       if (footerCopyright.innerHTML !== copy) footerCopyright.innerHTML = copy;
     }
   }
-
-  loadScript("../assets/runtime-config.js", "data-kc-runtime", "20260807-1");
-  loadScript("../assets/observability.js", "data-kc-observability", "20260807-1");
-  loadScript("./security-hardening-v1.js", "data-kc-security-hardening", "20260807-1");
-  loadScript("../metrics-v1.js", "data-kc-launch-metrics", "20260809-ownedobs1");
-
-  // Orden deliberado: primero existe un único opener; luego el controlador de clicks.
-  loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260809-directnav1");
-  loadScript("./academy-owned-native-bridge-v1.js", "data-kc-owned-native-bridge", "20260809-ownedopener1");
-
-  loadScript("./mi-kinecheck-v1.js", "data-mi-kinecheck", "20260809-directnav2");
-  loadScript("./mi-kinecheck-card-copy-v1.js", "data-mi-kinecheck-card-copy", "20260806-unified1");
-  loadScript("./mi-kinecheck-simplify-v2.js", "data-mi-kinecheck-simplify-v2", "20260810-interactionfix1");
-  loadScript("./academy-clinico-course-v1.js", "data-kc-clinico-course", "20260806-final5");
 
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", applyIdentity, { once: true });

--- a/academy/academy-reviews.js
+++ b/academy/academy-reviews.js
@@ -3,69 +3,6 @@
   const SESSION_KEY = "kinecheck_secure_session_v1";
   const state = { course: null, rating: 0, existing: null };
 
-  function loadAcademyEvidenceExtension() {
-    if (!document.querySelector('link[data-academy-evidence]')) {
-      const stylesheet = document.createElement("link");
-      stylesheet.rel = "stylesheet";
-      stylesheet.href = "./academy-evidence-alerts.css?v=20260731-2";
-      stylesheet.dataset.academyEvidence = "styles";
-      document.head.appendChild(stylesheet);
-    }
-
-    if (!document.querySelector('script[data-academy-evidence]')) {
-      const script = document.createElement("script");
-      script.src = "./academy-evidence-alerts.js?v=20260731-2";
-      script.dataset.academyEvidence = "script";
-      script.defer = true;
-      document.head.appendChild(script);
-    }
-  }
-
-  function loadLearningPathExtension() {
-    if (!document.querySelector('link[data-kinecheck-learning-path]')) {
-      const stylesheet = document.createElement("link");
-      stylesheet.rel = "stylesheet";
-      stylesheet.href = "./academy-learning-path-v4.css?v=20260810-interactionfix1";
-      stylesheet.dataset.kinecheckLearningPath = "styles";
-      document.head.appendChild(stylesheet);
-    }
-
-    if (!document.querySelector('script[data-kinecheck-learning-path]')) {
-      const script = document.createElement("script");
-      script.src = "./academy-learning-path-v4.js?v=20260810-interactionfix1";
-      script.dataset.kinecheckLearningPath = "script";
-      script.defer = true;
-      document.head.appendChild(script);
-    }
-  }
-
-  function loadIntegrationGuardExtension() {
-    if (document.querySelector('script[data-kinecheck-integration-guard]')) return;
-    const script = document.createElement("script");
-    script.src = "./academy-integration-guard-v4.js?v=20260803-sessionfix2";
-    script.dataset.kinecheckIntegrationGuard = "script";
-    script.defer = true;
-    document.head.appendChild(script);
-  }
-
-  function loadLaunchRouterExtension() {
-    if (document.querySelector('script[data-kinecheck-launch-router]')) return;
-    const script = document.createElement("script");
-    script.src = "./academy-launch-router-v4.js?v=20260803-sessionfix2";
-    script.dataset.kinecheckLaunchRouter = "script";
-    script.defer = true;
-    document.head.appendChild(script);
-  }
-
-  function loadCommerceExtension() {
-    if (document.querySelector('script[data-kinecheck-commerce]')) return;
-    const script = document.createElement("script");
-    script.src = "./academy-commerce-v4.js?v=20260801-stable2";
-    script.dataset.kinecheckCommerce = "v4";
-    script.defer = true;
-    document.head.appendChild(script);
-  }
-
   function session() {
     const provided = window.KINECHECK_ACADEMY_SESSION?.get?.();
     if (provided?.access_token) return provided;
@@ -228,11 +165,6 @@
   }
 
   document.addEventListener("DOMContentLoaded", () => {
-    loadAcademyEvidenceExtension();
-    loadLearningPathExtension();
-    loadIntegrationGuardExtension();
-    loadLaunchRouterExtension();
-    loadCommerceExtension();
     createModal();
     addReviewActions();
     const catalog = document.querySelector("#course-grid");

--- a/academy/index.html
+++ b/academy/index.html
@@ -15,12 +15,33 @@
   <link rel="stylesheet" href="./academy-v40.css?v=41">
   <link rel="stylesheet" href="./academy-evidence-alerts.css?v=20260731-2" data-academy-evidence="styles">
   <link rel="stylesheet" href="./academy-kinecheck-v4.css?v=20260731-1">
-  <script src="./academy-bootstrap-v28.js?v=20260809-private1" defer></script>
-  <script src="../watermark.js?v=20260730b" defer></script>
+  <link rel="stylesheet" href="./mi-kinecheck-v1.css?v=20260809-directnav2" data-mi-kinecheck="true">
+  <link rel="stylesheet" href="./mi-kinecheck-simplify-v2.css?v=20260810-runtime1" data-mi-kinecheck-simplify-v2="true">
+
+  <!--
+    Orden canónico del runtime de Academy.
+    Los módulos no deben inyectar otros scripts: todos se declaran aquí con defer
+    para que la inicialización sea determinista incluso con red o caché lentas.
+  -->
+  <script src="./academy-bootstrap-v28.js?v=20260810-runtime1" defer></script>
+  <script src="../watermark.js?v=20260810-runtime1" defer></script>
   <script src="./academy-v39.js?v=20260803-sessionfix2" defer></script>
   <script src="./academy-evidence-alerts.js?v=20260803-stable2" data-academy-evidence="script" defer></script>
-  <script src="./academy-reviews.js?v=20260810-interactionfix1" defer></script>
+  <script src="./academy-reviews.js?v=20260810-runtime1" defer></script>
   <script src="./academy-kinecheck-v4.js?v=20260803-stable2" defer></script>
+  <script src="../assets/runtime-config.js?v=20260807-1" data-kc-runtime="true" defer></script>
+  <script src="../assets/observability.js?v=20260807-1" data-kc-observability="true" defer></script>
+  <script src="./security-hardening-v1.js?v=20260807-1" data-kc-security-hardening="true" defer></script>
+  <script src="../metrics-v1.js?v=20260809-ownedobs1" data-kc-launch-metrics="true" defer></script>
+  <script src="./academy-open-v6.js?v=20260809-directnav1" data-kc-open-v6="true" defer></script>
+  <script src="./academy-owned-native-bridge-v1.js?v=20260809-ownedopener1" data-kc-owned-native-bridge="true" defer></script>
+  <script src="./mi-kinecheck-v1.js?v=20260809-directnav2" data-mi-kinecheck="true" defer></script>
+  <script src="./mi-kinecheck-card-copy-v1.js?v=20260806-unified1" data-mi-kinecheck-card-copy="true" defer></script>
+  <script src="./mi-kinecheck-simplify-v2.js?v=20260810-runtime1" data-mi-kinecheck-simplify-v2="true" defer></script>
+  <script src="./academy-clinico-course-v1.js?v=20260806-final5" data-kc-clinico-course="true" defer></script>
+  <script src="./academy-commerce-v4.js?v=20260801-stable2" data-kinecheck-commerce="v4" defer></script>
+  <script src="./academy-access-recovery-v1.js?v=20260803-accessfix1" data-kc-access-recovery="true" defer></script>
+  <script src="./academy-brand-identity.js?v=20260810-runtime1" data-kc-brand-identity="true" defer></script>
 </head>
 <body data-kc-view="inicio">
   <a class="skip-link" href="#contenido-principal">Saltar al contenido</a>

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -1,0 +1,34 @@
+# Arquitectura de runtime público
+
+## Portada
+
+La portada pública se compone desde `index.html` y carga únicamente:
+
+- `kinecheck/site-v5.css`
+- `kinecheck/site-v5.js`
+
+Los archivos `home.js`, `home-core-20260806.js`, `home-commercial-proof-v1.js` y
+`home-experience-unification-v1.js` pertenecen a iteraciones anteriores. No forman
+parte del runtime vigente y no deben usarse para corregir la portada actual.
+
+## Mi KineCheck / Academy
+
+`academy/index.html` es la única autoridad para declarar y ordenar los scripts de
+Academy. Todos se cargan con `defer` y ningún módulo funcional debe crear o inyectar
+otro `<script>`.
+
+El selector de etapa de `academy-learning-path-v4.js` es legado y no se carga. La
+experiencia actual infiere el perfil desde los productos activos sin bloquear la
+página con un modal.
+
+## Invariantes
+
+1. La portada no carga ningún `home*.js` legado.
+2. Academy no carga `academy-learning-path-v4.js`,
+   `academy-integration-guard-v4.js` ni `academy-launch-router-v4.js`.
+3. `academy-bootstrap-v28.js`, `academy-reviews.js` y
+   `academy-brand-identity.js` no inyectan scripts dinámicos.
+4. La ausencia de la capa visual `mi-kinecheck-simplify-v2.js` no puede bloquear
+   el desplazamiento, los controles ni la navegación base.
+
+Estos contratos están cubiertos por pruebas estáticas y de navegador.

--- a/tests/live-academy-runtime.spec.mjs
+++ b/tests/live-academy-runtime.spec.mjs
@@ -280,3 +280,48 @@ test("Academy no conserva overlays invisibles ni bloquea el scroll o los control
   await expect.poll(() => page.evaluate(() => document.body.className)).not.toContain("modal-open");
   await expect.poll(() => page.evaluate(() => document.body.className)).not.toContain("review-open");
 });
+
+test("Academy sigue operativa si falla la capa visual simplificada", async ({ page }) => {
+  await page.setViewportSize({ width: 1366, height: 768 });
+  await page.addInitScript(() => {
+    localStorage.setItem("kinecheck_secure_session_v1", JSON.stringify({
+      access_token: "qa-owner-access-token-with-safe-runtime-length",
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      expires_in: 3600,
+      token_type: "bearer",
+      user: { id: "qa-owner-user", email: "emmanuelkine@gmail.com" },
+    }));
+    localStorage.removeItem("kinecheck_learning_stage_v1:emmanuelkine@gmail.com");
+  });
+
+  await page.route("**/mi-kinecheck-simplify-v2.js*", (route) => route.abort("failed"));
+  await page.route("**/auth/v1/user", (route) => route.fulfill({
+    status: 200,
+    contentType: "application/json; charset=utf-8",
+    body: JSON.stringify({
+      id: "qa-owner-user",
+      email: "emmanuelkine@gmail.com",
+      created_at: "2026-01-01T00:00:00.000Z",
+    }),
+  }));
+  await page.route("**/functions/v1/metric-event", (route) => route.fulfill({
+    status: 202,
+    contentType: "application/json",
+    body: '{"ok":true}',
+  }));
+
+  await openAcademy(page, "simplify-asset-failure");
+  await expect(page.locator("#dashboard-view")).toBeVisible();
+  await expect(page.locator("#course-grid .course-card")).toHaveCount(9);
+  await page.waitForTimeout(900);
+
+  expect(await page.locator("#kc-stage-modal").count()).toBe(0);
+  await expect(page.locator("body")).not.toHaveClass(/kc-stage-modal-open/);
+  await expect(page.locator("body")).not.toHaveClass(/review-open/);
+  expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe("hidden");
+
+  await page.locator('.topbar-nav [data-kc-view-link="biblioteca"]').click();
+  await expect(page.locator("body")).toHaveAttribute("data-kc-view", "biblioteca");
+  await page.evaluate(() => window.scrollTo(0, 600));
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+});

--- a/tests/public-source-regression.test.mjs
+++ b/tests/public-source-regression.test.mjs
@@ -77,6 +77,73 @@ test("la portada conserva soporte, precios y accesos canónicos", async () => {
   assert.equal(count(home, 'class="icon" aria-hidden="true"'), 3);
 });
 
+test("portada y Academy tienen una única composición de scripts", async () => {
+  const home = await read("index.html");
+  const academy = await read("academy/index.html");
+
+  assert.match(home, /<script src="\.\/kinecheck\/site-v5\.js\?v=3" defer><\/script>/);
+  for (const legacy of [
+    "home.js",
+    "home-core-20260806.js",
+    "home-commercial-proof-v1.js",
+    "home-experience-unification-v1.js",
+  ]) {
+    assert.ok(!home.includes(legacy), `la portada volvió a cargar ${legacy}`);
+  }
+
+  const orderedRuntime = [
+    "academy-bootstrap-v28.js",
+    "academy-v39.js",
+    "academy-open-v6.js",
+    "academy-owned-native-bridge-v1.js",
+    "mi-kinecheck-v1.js",
+    "mi-kinecheck-simplify-v2.js",
+    "academy-commerce-v4.js",
+    "academy-access-recovery-v1.js",
+    "academy-brand-identity.js",
+  ];
+  let previous = -1;
+  for (const script of orderedRuntime) {
+    assert.equal(count(academy, script), 1, `${script} debe declararse una sola vez`);
+    const position = academy.indexOf(script);
+    assert.ok(position > previous, `${script} quedó fuera del orden canónico`);
+    previous = position;
+  }
+
+  for (const legacy of [
+    "academy-learning-path-v4.js",
+    "academy-integration-guard-v4.js",
+    "academy-launch-router-v4.js",
+  ]) {
+    assert.ok(!academy.includes(legacy), `Academy volvió a cargar el módulo legado ${legacy}`);
+  }
+
+  for (const path of [
+    "academy/academy-bootstrap-v28.js",
+    "watermark.js",
+    "academy/academy-v39.js",
+    "academy/academy-evidence-alerts.js",
+    "academy/academy-reviews.js",
+    "academy/academy-kinecheck-v4.js",
+    "assets/runtime-config.js",
+    "assets/observability.js",
+    "academy/security-hardening-v1.js",
+    "metrics-v1.js",
+    "academy/academy-open-v6.js",
+    "academy/academy-owned-native-bridge-v1.js",
+    "academy/mi-kinecheck-v1.js",
+    "academy/mi-kinecheck-card-copy-v1.js",
+    "academy/mi-kinecheck-simplify-v2.js",
+    "academy/academy-clinico-course-v1.js",
+    "academy/academy-commerce-v4.js",
+    "academy/academy-access-recovery-v1.js",
+    "academy/academy-brand-identity.js",
+  ]) {
+    const source = await read(path);
+    assert.ok(!source.includes('createElement("script")'), `${path} volvió a inyectar scripts dinámicos`);
+  }
+});
+
 test("ninguna superficie pública visible usa /platform/ ni CTAs vacíos", async () => {
   for (const path of await publicHtmlPaths()) {
     const source = await read(path);

--- a/watermark.js
+++ b/watermark.js
@@ -236,19 +236,4 @@
     },
   });
 
-  function loadAcademyCommerce() {
-    if (!window.location.pathname.includes("/academy/")) return;
-    if (document.querySelector('script[data-kinecheck-commerce]')) return;
-    const script = document.createElement("script");
-    script.src = "./academy-commerce-v4.js?v=20260801-1";
-    script.defer = true;
-    script.dataset.kinecheckCommerce = "v4";
-    document.head.appendChild(script);
-  }
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", loadAcademyCommerce, { once: true });
-  } else {
-    loadAcademyCommerce();
-  }
 })();


### PR DESCRIPTION
## Resumen

Consolida el runtime de **Mi KineCheck / Academy** para eliminar la carrera de carga que podía volver a bloquear el desplazamiento y los controles.

## Causa raíz comprobada

La portada actual no carga los cuatro scripts `home*.js` legados; usa únicamente `kinecheck/site-v5.js`. El conflicto real estaba en Academy: `academy-bootstrap-v28.js`, `academy-reviews.js`, `academy-brand-identity.js` y `watermark.js` inyectaban módulos dinámicamente desde distintos puntos.

Al retrasar `mi-kinecheck-simplify-v2.js` se reprodujo el fallo exacto: el selector de etapa legado se abría primero, añadía `kc-stage-modal-open` y dejaba `overflow: hidden`, bloqueando scroll y clics.

## Cambios

- convierte `academy/index.html` en la única autoridad del orden de scripts;
- declara los módulos con `defer` en orden determinista;
- elimina la inyección dinámica de scripts desde bootstrap, reseñas, identidad y marca de agua;
- retira del runtime el selector de etapa y los routers legados que ya estaban ocultos;
- mantiene la recuperación de bloqueos antiguos para pestañas restauradas;
- documenta la arquitectura vigente y los archivos `home*.js` que ya no forman parte de producción;
- añade invariantes estáticos y una prueba que aborta deliberadamente la capa visual para comprobar que Academy sigue navegable.

## Validación

- 16/16 regresiones estáticas y de privacidad;
- 9/9 botones recomendados y de productos adquiridos en Chromium;
- 7/7 runtime, scroll, navegación y SSO de aplicaciones en Chromium;
- 3/3 perfiles de Mi KineCheck;
- QA pública en móvil, tableta y escritorio;
- CI ejecutará los mismos gates en Chromium y WebKit.

## Alcance protegido

No modifica reglas de licencias, compras, usuarios, Hotmart, Supabase, secretos, productos, propietario, tester ni destinos SSO.