### PR TITLE
Consolida el control de interacción de Academy

### DIFF
--- a/academy/academy-brand-identity.js
+++ b/academy/academy-brand-identity.js
@@ -89,7 +89,7 @@
 
   // Orden deliberado: primero existe un único opener; luego el controlador de clicks.
   loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260809-directnav1");
-  loadScript("./academy-owned-native-bridge-v1.js", "data-kc-owned-native-bridge", "20260809-ownedopener1");
+  loadScript("./academy-owned-native-bridge-v1.js", "data-kc-owned-native-bridge", "20260810-controller1");
 
   loadScript("./mi-kinecheck-v1.js", "data-mi-kinecheck", "20260809-directnav2");
   loadScript("./mi-kinecheck-card-copy-v1.js", "data-mi-kinecheck-card-copy", "20260806-unified1");

--- a/academy/academy-owned-native-bridge-v1.js
+++ b/academy/academy-owned-native-bridge-v1.js
@@ -141,6 +141,28 @@
     event.stopImmediatePropagation();
   }
 
+  function reconcileInteractionLocks() {
+    const stageModal = document.querySelector("#kc-stage-modal");
+    if (stageModal) {
+      if (!stageModal.hidden) stageModal.hidden = true;
+      if (stageModal.getAttribute("aria-hidden") !== "true") stageModal.setAttribute("aria-hidden", "true");
+      if (!stageModal.hasAttribute("inert")) stageModal.setAttribute("inert", "");
+    }
+    if (document.body.classList.contains("kc-stage-modal-open")) {
+      document.body.classList.remove("kc-stage-modal-open");
+    }
+
+    const reviewModal = document.querySelector("#review-modal");
+    const reviewIsOpen = Boolean(reviewModal && !reviewModal.hidden);
+    if (document.body.classList.contains("review-open") !== reviewIsOpen) {
+      document.body.classList.toggle("review-open", reviewIsOpen);
+    }
+
+    if (!reviewIsOpen && getComputedStyle(document.body).overflow === "hidden") {
+      document.body.style.removeProperty("overflow");
+    }
+  }
+
   window.addEventListener("click", (event) => {
     const target = event.target instanceof Element ? event.target : null;
     if (!target) return;
@@ -241,5 +263,21 @@
 
   window.addEventListener("pageshow", () => {
     window.KINECHECK_RESET_PRODUCT_NAVIGATION?.();
+    reconcileInteractionLocks();
+  });
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", reconcileInteractionLocks, { once: true });
+  } else {
+    reconcileInteractionLocks();
+  }
+
+  const lockObserver = new MutationObserver(reconcileInteractionLocks);
+  lockObserver.observe(document.body, { attributes: true, attributeFilter: ["class"] });
+  lockObserver.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["hidden"],
   });
 })();

--- a/academy/academy-reviews.js
+++ b/academy/academy-reviews.js
@@ -21,42 +21,6 @@
     }
   }
 
-  function loadLearningPathExtension() {
-    if (!document.querySelector('link[data-kinecheck-learning-path]')) {
-      const stylesheet = document.createElement("link");
-      stylesheet.rel = "stylesheet";
-      stylesheet.href = "./academy-learning-path-v4.css?v=20260810-interactionfix1";
-      stylesheet.dataset.kinecheckLearningPath = "styles";
-      document.head.appendChild(stylesheet);
-    }
-
-    if (!document.querySelector('script[data-kinecheck-learning-path]')) {
-      const script = document.createElement("script");
-      script.src = "./academy-learning-path-v4.js?v=20260810-interactionfix1";
-      script.dataset.kinecheckLearningPath = "script";
-      script.defer = true;
-      document.head.appendChild(script);
-    }
-  }
-
-  function loadIntegrationGuardExtension() {
-    if (document.querySelector('script[data-kinecheck-integration-guard]')) return;
-    const script = document.createElement("script");
-    script.src = "./academy-integration-guard-v4.js?v=20260803-sessionfix2";
-    script.dataset.kinecheckIntegrationGuard = "script";
-    script.defer = true;
-    document.head.appendChild(script);
-  }
-
-  function loadLaunchRouterExtension() {
-    if (document.querySelector('script[data-kinecheck-launch-router]')) return;
-    const script = document.createElement("script");
-    script.src = "./academy-launch-router-v4.js?v=20260803-sessionfix2";
-    script.dataset.kinecheckLaunchRouter = "script";
-    script.defer = true;
-    document.head.appendChild(script);
-  }
-
   function loadCommerceExtension() {
     if (document.querySelector('script[data-kinecheck-commerce]')) return;
     const script = document.createElement("script");
@@ -229,9 +193,6 @@
 
   document.addEventListener("DOMContentLoaded", () => {
     loadAcademyEvidenceExtension();
-    loadLearningPathExtension();
-    loadIntegrationGuardExtension();
-    loadLaunchRouterExtension();
     loadCommerceExtension();
     createModal();
     addReviewActions();

--- a/academy/index.html
+++ b/academy/index.html
@@ -19,7 +19,7 @@
   <script src="../watermark.js?v=20260730b" defer></script>
   <script src="./academy-v39.js?v=20260803-sessionfix2" defer></script>
   <script src="./academy-evidence-alerts.js?v=20260803-stable2" data-academy-evidence="script" defer></script>
-  <script src="./academy-reviews.js?v=20260810-interactionfix1" defer></script>
+  <script src="./academy-reviews.js?v=20260810-controller1" defer></script>
   <script src="./academy-kinecheck-v4.js?v=20260803-stable2" defer></script>
 </head>
 <body data-kc-view="inicio">

--- a/tests/live-academy-runtime.spec.mjs
+++ b/tests/live-academy-runtime.spec.mjs
@@ -70,6 +70,9 @@ test("Mis productos registra el toque, usa el opener real y completa una navegac
   expect(runtime.scripts.some((src) => src.includes("academy-brand-identity.js"))).toBeTruthy();
   expect(runtime.scripts.some((src) => src.includes("academy-open-v6.js"))).toBeTruthy();
   expect(runtime.scripts.some((src) => src.includes("academy-owned-native-bridge-v1.js"))).toBeTruthy();
+  expect(runtime.scripts.some((src) => src.includes("academy-learning-path-v4.js"))).toBeFalsy();
+  expect(runtime.scripts.some((src) => src.includes("academy-launch-router-v4.js"))).toBeFalsy();
+  expect(runtime.scripts.some((src) => src.includes("academy-integration-guard-v4.js"))).toBeFalsy();
   expect(["none", "not-rendered"]).toContain(runtime.watermarkPointerEvents);
 
   await page.route("**/comunicacion-clinica.html?*", async (route) => {
@@ -252,7 +255,7 @@ test("Academy no conserva overlays invisibles ni bloquea el scroll o los control
   expect(interactionState.bodyClass).not.toContain("kc-stage-modal-open");
   expect(interactionState.bodyOverflow).not.toBe("hidden");
   expect(interactionState.documentOverflow).not.toBe("hidden");
-  expect(interactionState.modalHidden || interactionState.modalDisplay === "none").toBeTruthy();
+  expect(interactionState.modalDisplay).toBe("missing");
   expect(interactionState.scrollHeight).toBeGreaterThan(interactionState.viewportHeight);
 
   await page.evaluate(() => window.scrollTo(0, 700));


### PR DESCRIPTION
## Qué cambia

- Elimina desde `academy-reviews.js` la carga indirecta de tres extensiones heredadas sin relación con las reseñas.
- Centraliza la reconciliación de overlays, clases de bloqueo y `overflow` en el controlador nativo de interacción.
- Protege restauración de pestañas (`pageshow`) y cambios tardíos del DOM.
- Añade regresiones para impedir que vuelvan a cargarse los controladores redundantes o reaparezca el modal fantasma.

## Causa raíz

Academy cargaba controladores heredados desde el módulo de reseñas. Uno de ellos podía activar el selector de etapa después de que la interfaz nueva lo hubiera ocultado, dejando `kc-stage-modal-open` y `overflow: hidden`; eso bloqueaba el desplazamiento y los clics.

## Validación local

- 15/15 invariantes de fuente y seguridad.
- 6/6 pruebas del runtime real de Academy y relay SSO en Chromium.
- 9/9 pruebas de botones recomendados, productos adquiridos, navegación, soporte e historial.
- Total: 30/30 pruebas aprobadas.

## Alcance protegido

No modifica API, SSO, licencias, compras, Hotmart, Supabase, usuarios, secretos ni reglas de acceso.