### PR TITLE
Corrige únicamente el botón Continuar curso

### DIFF
--- a/academy/academy-brand-identity.js
+++ b/academy/academy-brand-identity.js
@@ -89,7 +89,7 @@
 
   // Orden deliberado: primero existe un único opener; luego el controlador de clicks.
   loadScript("./academy-open-v6.js", "data-kc-open-v6", "20260809-directnav1");
-  loadScript("./academy-owned-native-bridge-v1.js", "data-kc-owned-native-bridge", "20260810-controller1");
+  loadScript("./academy-owned-native-bridge-v1.js", "data-kc-owned-native-bridge", "20260810-continue1");
 
   loadScript("./mi-kinecheck-v1.js", "data-mi-kinecheck", "20260809-directnav2");
   loadScript("./mi-kinecheck-card-copy-v1.js", "data-mi-kinecheck-card-copy", "20260806-unified1");

--- a/academy/academy-owned-native-bridge-v1.js
+++ b/academy/academy-owned-native-bridge-v1.js
@@ -4,14 +4,13 @@
   if (window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__) return;
   window.__KINECHECK_OWNED_NATIVE_BRIDGE_V1__ = true;
 
-  // Solo intercepta entradas proxy creadas por Inicio, Mi KineCheck y recomendaciones.
-  // Todas esas entradas deben usar el mismo opener unificado que ya funciona en las
-  // recomendaciones. Los botones nativos de #course-grid y #continue-button conservan
-  // sus listeners de academy-v39.js y su validación nativa.
+  // Intercepta las entradas proxy y, de forma específica, el botón global Continuar.
+  // Las tarjetas nativas de #course-grid conservan intactos sus listeners probados.
   const PRODUCT_SELECTOR = [
     "[data-kc-open-product]",
     "[data-kc-open-owned]",
     "[data-kc-path-open]",
+    "#continue-button[data-course]",
   ].join(", ");
 
   const STUDENT_ORDER = [

--- a/tests/owned-buttons.spec.mjs
+++ b/tests/owned-buttons.spec.mjs
@@ -36,6 +36,7 @@ async function installHarness(page) {
         <button type="button" data-course="kinecheck-clinico-curso">Clínico curso</button>
         <button type="button" data-course="traumatologia-ortopedia-clinica">Trauma</button>
         <button type="button" data-course="kinecheck-recupera">Recupera</button>
+        <button type="button" data-course="evidencia-aplicada">Evidencia</button>
       </section>
 
       <button id="home-clinico" type="button" data-kc-open-product="kinecheck-clinico">Clínico</button>
@@ -89,7 +90,7 @@ test("tarjetas proxy usan el opener unificado y no duplican el flujo nativo", as
   await expect.poll(async () => page.evaluate(() => window.__openedCore)).toEqual([]);
 });
 
-test("botones nativos de course-grid y Continuar no son interceptados por el bridge", async ({ page }) => {
+test("Continuar usa el opener unificado sin alterar los botones nativos del catálogo", async ({ page }) => {
   await installHarness(page);
 
   await page.locator('#course-grid [data-course="comunicacion-clinica"]').click();
@@ -100,11 +101,11 @@ test("botones nativos de course-grid y Continuar no son interceptados por el bri
     "comunicacion-clinica",
     "kinecheck-clinico-curso",
   ]);
-  await expect.poll(async () => page.evaluate(() => window.__nativeContinueClicks)).toEqual([
+  await expect.poll(async () => page.evaluate(() => window.__nativeContinueClicks)).toEqual([]);
+  await expect.poll(async () => page.evaluate(() => window.__openedCore)).toEqual([]);
+  await expect.poll(async () => page.evaluate(() => window.__openedUnified)).toEqual([
     "evidencia-aplicada",
   ]);
-  await expect.poll(async () => page.evaluate(() => window.__openedCore)).toEqual([]);
-  await expect.poll(async () => page.evaluate(() => window.__openedUnified)).toEqual([]);
 });
 
 test("Continuar actividad usa el opener unificado con el producto recordado", async ({ page }) => {


### PR DESCRIPTION
## Qué cambia

- Enruta únicamente `#continue-button` mediante el lanzador unificado ya probado.
- Mantiene intactos los botones nativos `Comenzar curso` y `Continuar curso` de las tarjetas del catálogo.
- Actualiza la prueba para exigir navegación del botón global y comprobar que las tarjetas no son interceptadas.

## Causa

El botón global `Continuar curso` dependía de un listener nativo separado, mientras el acceso al producto ya contaba con un lanzador unificado resiliente.

## Validación

- 80/80 controles de acceso del ecosistema.
- `git diff --check` limpio.
- Chromium y WebKit quedan como gates obligatorios del PR.

## Fuera de alcance

Sin cambios en SSO, licencias, compras, Hotmart, Supabase, usuarios ni secretos.