### PR TITLE
Mostrar Ejercicio Terapéutico como PRÓXIMAMENTE

### DIFF
--- a/academy/academy-access-recovery-v1.js
+++ b/academy/academy-access-recovery-v1.js
@@ -13,6 +13,12 @@
   const SSO_HANDOFF_TYPE = CONFIG.appSso?.handoffType || "kinecheck-sso-v3-access-only";
 
   const PREPARING_PRODUCTS = Object.freeze({
+    "ejercicio-terapeutico": Object.freeze({
+      badge: "PRÓXIMAMENTE",
+      meta: "Próximo lanzamiento · curso en revisión",
+      lockedLabel: "Próximamente",
+      reviewLabel: "Abrir versión de revisión",
+    }),
     "banderas-clinicas": Object.freeze({
       badge: "EN CONSTRUCCIÓN",
       meta: "Próximo lanzamiento · contenido en desarrollo",

--- a/academy/academy-bootstrap-v28.js
+++ b/academy/academy-bootstrap-v28.js
@@ -468,7 +468,7 @@ window.KINECHECK_ACADEMY_CONFIG = Object.freeze({
 (() => {
   if (document.querySelector('script[data-kc-access-recovery]')) return;
   const script = document.createElement("script");
-  script.src = "./academy-access-recovery-v1.js?v=20260821-buttons-hotfix1";
+  script.src = "./academy-access-recovery-v1.js?v=20260823-ejercicio-proximamente1";
   script.defer = true;
   script.dataset.kcAccessRecovery = "true";
   document.head.appendChild(script);

--- a/tests/owned-buttons.spec.mjs
+++ b/tests/owned-buttons.spec.mjs
@@ -127,6 +127,12 @@ test("productos activos permiten verificar acceso y los que están en preparaci�
           <div class="course-meta">Licencia asociada a la compra</div>
           <button class="course-button" type="button" data-course="dolor-musculoesqueletico" disabled>No disponible en tu cuenta</button>
         </article>
+        <article data-card-course="ejercicio-terapeutico">
+          <span class="status-badge">Disponible</span>
+          <h3>Ejercicio Terapéutico</h3>
+          <div class="course-meta">Versión en desarrollo</div>
+          <button class="course-button" type="button" data-course="ejercicio-terapeutico">Comenzar curso</button>
+        </article>
         <article data-card-course="banderas-clinicas">
           <span class="status-badge">Disponible</span>
           <h3>KineCheck Banderas Clínicas</h3>
@@ -141,6 +147,7 @@ test("productos activos permiten verificar acceso y los que están en preparaci�
     window.KINECHECK_ACADEMY_CONFIG = {
       courses: [
         { slug: "dolor-musculoesqueletico" },
+        { slug: "ejercicio-terapeutico" },
         { slug: "banderas-clinicas" },
       ],
     };
@@ -153,6 +160,20 @@ test("productos activos permiten verificar acceso y los que están en preparaci�
   await expect(dm.locator('button[data-course="dolor-musculoesqueletico"]')).toBeHidden();
   await expect(page.locator('[data-kc-retry-access="dolor-musculoesqueletico"]')).toHaveText("Verificar acceso");
   await expect(page.locator('[data-kc-retry-access="dolor-musculoesqueletico"]')).toBeEnabled();
+
+  const exercise = page.locator('[data-card-course="ejercicio-terapeutico"]');
+  const exerciseButton = exercise.locator('button[data-course="ejercicio-terapeutico"]');
+  await expect(exercise.locator(".status-badge")).toHaveText("PRÓXIMAMENTE");
+  await expect(exercise.locator(".course-meta")).toContainText("Próximo lanzamiento");
+  await expect(exerciseButton).toHaveText("Abrir versión de revisión");
+  await expect(exerciseButton).toBeEnabled();
+
+  await exerciseButton.evaluate((button) => {
+    button.disabled = true;
+  });
+  await expect(exerciseButton).toHaveText("Próximamente");
+  await expect(exerciseButton).toBeDisabled();
+  await expect(page.locator('[data-kc-retry-access="ejercicio-terapeutico"]')).toHaveCount(0);
 
   const flags = page.locator('[data-card-course="banderas-clinicas"]');
   await expect(flags.locator(".status-badge")).toHaveText("EN CONSTRUCCIÓN");


### PR DESCRIPTION
## Resumen
- mantiene Ejercicio Terapéutico integrado en la Biblioteca de KineCheck Academy
- muestra `PRÓXIMAMENTE` a estudiantes y visitantes sin licencia
- conserva `Abrir versión de revisión` para el propietario
- actualiza la versión de caché del estado y su cobertura automatizada

## Validación
- 11/11 pruebas de botones y estados aprobadas
- invariantes de privacidad aprobadas
- healthcheck integral: 0 fallos y 0 advertencias