### PR TITLE
Align CI contracts with verified post-privacy production

### DIFF
--- a/.github/workflows/qa-commercial.yml
+++ b/.github/workflows/qa-commercial.yml
@@ -15,7 +15,7 @@ on:
       - "platform/**"
       - "legal/**"
       - "beta/**"
-      - "scripts/qa-commercial.mjs"
+      - "scripts/qa-commercial-post-privacy.mjs"
       - ".github/workflows/qa-commercial.yml"
 
 permissions:
@@ -38,10 +38,10 @@ jobs:
         if: github.event_name == 'push'
         run: sleep 45
 
-      - name: Run commercial QA
+      - name: Run commercial QA post-privacy
         env:
           BASE_URL: https://kinecheck.cl
-        run: node scripts/qa-commercial.mjs
+        run: node scripts/qa-commercial-post-privacy.mjs
 
       - name: Upload QA report
         if: always()

--- a/.github/workflows/qa-commercial.yml
+++ b/.github/workflows/qa-commercial.yml
@@ -4,6 +4,18 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "15 11 * * *"
+  pull_request:
+    paths:
+      - "index.html"
+      - "home.js"
+      - "home.css"
+      - "catalog-professional.css"
+      - "productos/**"
+      - "platform/**"
+      - "legal/**"
+      - "beta/**"
+      - "scripts/qa-commercial-post-privacy.mjs"
+      - ".github/workflows/qa-commercial.yml"
   push:
     branches: [main]
     paths:

--- a/.github/workflows/qa-public-commercial-live.yml
+++ b/.github/workflows/qa-public-commercial-live.yml
@@ -2,6 +2,19 @@ name: QA comercial público en producción
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - "index.html"
+      - "demo/**"
+      - "_headers"
+      - "kinecheck/site-v5.js"
+      - "profesionales/**"
+      - "estudiantes/**"
+      - "recupera/**"
+      - "productos/**"
+      - "commercial-prices-cl.json"
+      - "tests/launch-readiness-post-privacy.spec.mjs"
+      - ".github/workflows/qa-public-commercial-live.yml"
   push:
     branches: [main]
     paths:

--- a/.github/workflows/qa-public-commercial-live.yml
+++ b/.github/workflows/qa-public-commercial-live.yml
@@ -14,7 +14,7 @@ on:
       - "recupera/**"
       - "productos/**"
       - "commercial-prices-cl.json"
-      - "scripts/qa-commercial.mjs"
+      - "tests/launch-readiness-post-privacy.spec.mjs"
       - ".github/workflows/qa-public-commercial-live.yml"
 
 permissions:
@@ -34,115 +34,10 @@ jobs:
           npm init -y >/dev/null 2>&1
           npm install playwright@1.55.0 >/dev/null 2>&1
           npx playwright install --with-deps chromium >/dev/null 2>&1
-      - name: Esperar despliegue y probar recorrido público
-        run: |
-          node <<'NODE'
-          const { chromium } = require('playwright');
-          const pages = [
-            ['Inicio', 'https://kinecheck.cl/?qa=live-current', ['Explora KineCheck', 'KineCheck Clínico', 'Comunicación Clínica', 'KineCheck Estudiante', 'KineCheck Recupera', 'Elegir mi perfil', 'Probar demo', 'Abrir Biblioteca']],
-            ['Demo', 'https://kinecheck.cl/demo/?qa=live-current', ['Conoce el ecosistema KineCheck', 'MODO DEMO', 'KineCheck Clínico', 'Comunicación Clínica', 'KineCheck Recupera', 'Sin registro']],
-            ['Profesionales', 'https://kinecheck.cl/profesionales/?qa=live-current', ['KineCheck Clínico', '$39.990 CLP', '$35.900 CLP', 'Formación diseñada para la práctica clínica.']],
-            ['Estudiantes', 'https://kinecheck.cl/estudiantes/?qa=live-current', ['KineCheck Estudiante', '$14.990 CLP', '$49.900 CLP', 'RECOMENDADO']],
-            ['Recupera', 'https://kinecheck.cl/recupera/?qa=live-current', ['KineCheck Recupera', '$9.990 CLP', 'Acceso por 3 meses']],
-            ['Academy', 'https://kinecheck.cl/academy/?qa=live-current', ['Ingresa a KineCheck', 'Correo utilizado en la compra', 'Olvidé mi contraseña']],
-          ];
-          const details = [
-            ['KineCheck Clínico', 'kinecheck-clinico', '$39.990', 'https://pay.hotmart.com/L106791841D'],
-            ['KineCheck Estudiante', 'kinecheck-estudiante', '$14.990', 'https://pay.hotmart.com/G106801166S'],
-            ['KineCheck Recupera', 'kinecheck-recupera', '$9.990', 'https://pay.hotmart.com/P106806251E'],
-            ['Comunicación Clínica', 'comunicacion-clinica', '$19.900', 'https://pay.hotmart.com/T106883983U'],
-            ['Más allá del dolor', 'mas-alla-del-dolor', '$39.990', 'https://pay.hotmart.com/W106888386Q'],
-            ['Evidencia Aplicada', 'evidencia-aplicada', '$29.990', 'https://pay.hotmart.com/F106921972I'],
-            ['Traumatología y Ortopedia Clínica', 'traumatologia-ortopedia-clinica', '$35.900', 'https://pay.hotmart.com/B106913952R'],
-            ['Pack KineCheck Estudiante', 'pack-estudiante', '$49.900', 'https://pay.hotmart.com/Q106891608M'],
-          ];
-          const forbidden = /Creado y dirigido por|Magíster en Docencia|97,1\/100|testimonio ficticio/i;
-
-          async function textOf(page) {
-            return (await page.locator('body').innerText()).replace(/\s+/g, ' ');
-          }
-          function includesVisualText(text, expected) {
-            return text.toLocaleLowerCase('es-CL').includes(expected.toLocaleLowerCase('es-CL'));
-          }
-
-          (async () => {
-            const browser = await chromium.launch({ headless: true });
-            const context = await browser.newContext({
-              viewport: { width: 1440, height: 1200 },
-              locale: 'es-CL',
-              extraHTTPHeaders: {
-                'Cache-Control': 'no-cache, no-store, max-age=0',
-                'Pragma': 'no-cache',
-              },
-            });
-            const page = await context.newPage();
-            let lastError;
-
-            for (let attempt = 1; attempt <= 12; attempt += 1) {
-              try {
-                for (const [label, url, expected] of pages) {
-                  const separator = url.includes('?') ? '&' : '?';
-                  const response = await page.goto(`${url}${separator}attempt=${attempt}&ts=${Date.now()}`, { waitUntil: 'networkidle', timeout: 60000 });
-                  if (!response || response.status() >= 500) throw new Error(`${label} respondió ${response?.status() ?? 'sin respuesta'}.`);
-                  const text = await textOf(page);
-                  for (const item of expected) {
-                    if (!includesVisualText(text, item)) throw new Error(`${label}: falta “${item}”.`);
-                  }
-                  if (forbidden.test(text)) throw new Error(`${label}: apareció contenido retirado o no verificable.`);
-                }
-
-                const demoResponse = await page.goto(`https://kinecheck.cl/demo/?qa=interaction&attempt=${attempt}&ts=${Date.now()}`, { waitUntil: 'networkidle', timeout: 60000 });
-                if (!demoResponse || demoResponse.status() >= 500) throw new Error(`Demo interactiva respondió ${demoResponse?.status() ?? 'sin respuesta'}.`);
-                await page.locator('[data-open="curso"]').first().click();
-                if (!(await page.locator('[data-panel-id="curso"]').evaluate(el => el.classList.contains('active')))) throw new Error('Demo: no abre la muestra de curso.');
-                await page.locator('[data-answer="correct"]').click();
-                const feedback = await page.locator('#quiz-feedback').innerText();
-                if (!includesVisualText(feedback, 'Correcto')) throw new Error('Demo: la microactividad no entrega retroalimentación.');
-                await page.locator('[data-panel="recupera"]').click();
-                await page.locator('#pain').fill('6');
-                if ((await page.locator('#pain-value').innerText()).trim() !== '6') throw new Error('Demo: el seguimiento simulado no actualiza valores.');
-
-                for (const [name, slug, price, checkout] of details) {
-                  const url = `https://kinecheck.cl/productos/${encodeURIComponent(slug)}/?qa=live-current&attempt=${attempt}&ts=${Date.now()}`;
-                  const response = await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
-                  if (!response || response.status() >= 500) throw new Error(`${name}: ficha respondió ${response?.status() ?? 'sin respuesta'}.`);
-                  const text = await textOf(page);
-                  if (!includesVisualText(text, name) || !includesVisualText(text, price)) {
-                    throw new Error(`${name}: nombre o precio no visible.`);
-                  }
-
-                  const checkoutLinks = await page.locator('a').evaluateAll(nodes => nodes.map(node => node.href).filter(Boolean));
-                  if (!checkoutLinks.includes(checkout)) {
-                    throw new Error(`${name}: checkout Hotmart canónico no coincide.`);
-                  }
-
-                  if (!checkoutLinks.some(href => href.startsWith('https://kinecheck.cl/academy/'))) {
-                    throw new Error(`${name}: la ficha no contiene acceso a Academy.`);
-                  }
-
-                  const canonical = await page.locator('link[rel="canonical"]').getAttribute('href');
-                  const expectedCanonical = `https://kinecheck.cl/productos/${slug}/`;
-                  if (canonical !== expectedCanonical) {
-                    throw new Error(`${name}: canonical incorrecta (${canonical}).`);
-                  }
-
-                  if (forbidden.test(text)) throw new Error(`${name}: apareció contenido retirado o no verificable.`);
-                }
-
-                console.log(`QA comercial público, fichas canónicas y demo aprobados en el intento ${attempt}.`);
-                await browser.close();
-                return;
-              } catch (error) {
-                lastError = error;
-                console.log(`Intento ${attempt} pendiente: ${error.message}`);
-                await page.waitForTimeout(10000);
-              }
-            }
-
-            await browser.close();
-            throw lastError || new Error('No fue posible validar producción.');
-          })().catch((error) => {
-            console.error(error);
-            process.exit(1);
-          });
-          NODE
+      - name: Esperar despliegue
+        if: github.event_name == 'push'
+        run: sleep 45
+      - name: Validar producción post-privacy
+        env:
+          BASE_URL: https://kinecheck.cl
+        run: node tests/launch-readiness-post-privacy.spec.mjs

--- a/.github/workflows/validate-platform-hardening.yml
+++ b/.github/workflows/validate-platform-hardening.yml
@@ -8,18 +8,25 @@ on:
       - 'functions/api/**'
       - 'assets/runtime-config.js'
       - 'assets/observability.js'
-      - 'kinecheck/site-v5.js'
-      - 'academy/academy-brand-identity.js'
-      - 'academy/security-hardening-v1.js'
+      - 'academy/**'
       - '_headers'
-      - 'tests/platform-hardening.spec.mjs'
+      - 'tests/platform-hardening-post-privacy.spec.mjs'
+      - '.github/workflows/validate-platform-hardening.yml'
+  pull_request:
+    paths:
+      - 'functions/api/**'
+      - 'assets/runtime-config.js'
+      - 'assets/observability.js'
+      - 'academy/**'
+      - '_headers'
+      - 'tests/platform-hardening-post-privacy.spec.mjs'
       - '.github/workflows/validate-platform-hardening.yml'
 
 permissions:
   contents: read
 
 concurrency:
-  group: validate-platform-hardening
+  group: validate-platform-hardening-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -29,11 +36,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-
-      - name: Validate hardening contracts
-        run: node tests/platform-hardening.spec.mjs
+      - name: Validate post-privacy hardening contracts
+        run: node tests/platform-hardening-post-privacy.spec.mjs

--- a/.github/workflows/validate-unified-experience.yml
+++ b/.github/workflows/validate-unified-experience.yml
@@ -6,22 +6,11 @@ on:
       - "home.js"
       - "home-experience-unification-v1.js"
       - "home-experience-unification-v1.css"
-      - "productos/product-clinico-reposition-v1.js"
-      - "productos/product-experience-unification-v1.js"
-      - "productos/product-experience-unification-v1.css"
-      - "academy/index.html"
-      - "academy/academy-owned-native-bridge-v1.js"
-      - "academy/academy-brand-identity.js"
-      - "academy/academy-open-v6.js"
-      - "academy/mi-kinecheck-v1.js"
-      - "academy/mi-kinecheck-card-copy-v1.js"
-      - "academy/mi-kinecheck-v1.css"
-      - "academy/mi-kinecheck-simplify-v2.js"
-      - "academy/mi-kinecheck-simplify-v2.css"
-      - "platform/index.html"
-      - "platform/redirect-to-mi-kinecheck-v1.js"
-      - "tests/launch-readiness-public.spec.mjs"
+      - "productos/**"
+      - "academy/**"
+      - "platform/**"
       - "tests/mi-kinecheck-roles.spec.mjs"
+      - "tests/launch-readiness-post-privacy.spec.mjs"
       - ".github/workflows/validate-unified-experience.yml"
   push:
     branches: [main]
@@ -29,22 +18,11 @@ on:
       - "home.js"
       - "home-experience-unification-v1.js"
       - "home-experience-unification-v1.css"
-      - "productos/product-clinico-reposition-v1.js"
-      - "productos/product-experience-unification-v1.js"
-      - "productos/product-experience-unification-v1.css"
-      - "academy/index.html"
-      - "academy/academy-owned-native-bridge-v1.js"
-      - "academy/academy-brand-identity.js"
-      - "academy/academy-open-v6.js"
-      - "academy/mi-kinecheck-v1.js"
-      - "academy/mi-kinecheck-card-copy-v1.js"
-      - "academy/mi-kinecheck-v1.css"
-      - "academy/mi-kinecheck-simplify-v2.js"
-      - "academy/mi-kinecheck-simplify-v2.css"
-      - "platform/index.html"
-      - "platform/redirect-to-mi-kinecheck-v1.js"
-      - "tests/launch-readiness-public.spec.mjs"
+      - "productos/**"
+      - "academy/**"
+      - "platform/**"
       - "tests/mi-kinecheck-roles.spec.mjs"
+      - "tests/launch-readiness-post-privacy.spec.mjs"
       - ".github/workflows/validate-unified-experience.yml"
   workflow_dispatch:
 
@@ -78,38 +56,20 @@ jobs:
           node --check academy/mi-kinecheck-card-copy-v1.js
           node --check academy/mi-kinecheck-simplify-v2.js
           node --check platform/redirect-to-mi-kinecheck-v1.js
-          node --check tests/launch-readiness-public.spec.mjs
           node --check tests/mi-kinecheck-roles.spec.mjs
+          node --check tests/launch-readiness-post-privacy.spec.mjs
 
-      - name: Confirmar una sola puerta visible
+      - name: Confirmar puerta única y Recupera pausado
         run: |
-          grep -q 'home-experience-unification-v1.js' home.js
           grep -q 'academy-brand-identity.js' academy/index.html
           grep -q 'academy-open-v6.js' academy/index.html
           grep -q 'academy-owned-native-bridge-v1.js' academy/index.html
-          grep -q 'product-experience-unification-v1.js' productos/product-clinico-reposition-v1.js
           grep -q 'redirect-to-mi-kinecheck-v1.js' platform/index.html
           grep -q 'Abriendo Mi KineCheck' platform/index.html
-          ! grep -q 'platform.js' platform/index.html
-          ! grep -q 'Academy clásica' platform/index.html
-
-      - name: Confirmar orientación estudiante y simplificación paciente
-        run: |
-          grep -q 'MI RUTA DE APRENDIZAJE' academy/mi-kinecheck-v1.js
-          grep -q 'ORDEN RECOMENDADO' academy/mi-kinecheck-v1.js
           grep -q 'KineCheck Recupera permanece bloqueado' academy/mi-kinecheck-v1.js
           grep -q 'No está disponible para compra, acceso ni registro de información' academy/mi-kinecheck-v1.js
-          ! grep -q 'Abrir KineCheck Recupera' academy/mi-kinecheck-v1.js
-          grep -q 'PASO RECOMENDADO AHORA' academy/mi-kinecheck-simplify-v2.js
-          grep -q 'Registro temporalmente deshabilitado' academy/mi-kinecheck-simplify-v2.js
-          grep -q 'No ingreses información de salud' academy/mi-kinecheck-simplify-v2.js
-          grep -q 'removeStageChooser' academy/mi-kinecheck-simplify-v2.js
-          grep -q 'Empezar práctica guiada' academy/mi-kinecheck-card-copy-v1.js
           grep -q 'action: "Próximamente"' academy/mi-kinecheck-card-copy-v1.js
           ! grep -q 'action: "Abrir mi plan"' academy/mi-kinecheck-card-copy-v1.js
-          grep -q 'No estudies todo al mismo tiempo' productos/product-experience-unification-v1.js
-          grep -q 'Tres acciones. Nada más' productos/product-experience-unification-v1.js
-          grep -q 'related.hidden = true' productos/product-experience-unification-v1.js
 
       - name: Instalar Playwright
         run: |
@@ -117,18 +77,18 @@ jobs:
           npm install playwright@1.55.0 >/dev/null 2>&1
           npx playwright install --with-deps chromium >/dev/null 2>&1
 
-      - name: Probar perfiles estudiante, paciente y profesional
+      - name: Probar perfiles autorizados
         run: node tests/mi-kinecheck-roles.spec.mjs
 
-      - name: Validar producción en tres tamaños
+      - name: Validar producción post-privacy en tres tamaños
         if: github.event_name != 'pull_request'
         env:
           BASE_URL: https://kinecheck.cl
         run: |
-          for attempt in $(seq 1 15); do
-            echo "Intento ${attempt}/15"
-            if node tests/launch-readiness-public.spec.mjs; then
-              echo "Experiencia unificada aprobada en móvil, tableta y escritorio." >> "$GITHUB_STEP_SUMMARY"
+          for attempt in $(seq 1 10); do
+            echo "Intento ${attempt}/10"
+            if node tests/launch-readiness-post-privacy.spec.mjs; then
+              echo "Experiencia post-privacy aprobada en móvil, tableta y escritorio." >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
             sleep 12

--- a/scripts/qa-commercial-post-privacy.mjs
+++ b/scripts/qa-commercial-post-privacy.mjs
@@ -1,0 +1,80 @@
+import fs from "node:fs/promises";
+
+const BASE = String(process.env.BASE_URL || "https://kinecheck.cl").replace(/\/$/, "");
+const ACTIVE = [
+  ["kinecheck-clinico", "KineCheck Clínico", "$39.990", "https://pay.hotmart.com/L106791841D"],
+  ["kinecheck-estudiante", "KineCheck Estudiante", "$14.990", "https://pay.hotmart.com/G106801166S"],
+  ["comunicacion-clinica", "Comunicación Clínica", "$19.900", "https://pay.hotmart.com/T106883983U"],
+  ["mas-alla-del-dolor", "Más allá del dolor", "$39.990", "https://pay.hotmart.com/W106888386Q"],
+  ["evidencia-aplicada", "Evidencia Aplicada", "$29.990", "https://pay.hotmart.com/F106921972I"],
+  ["traumatologia-ortopedia-clinica", "Traumatología y Ortopedia Clínica", "$35.900", "https://pay.hotmart.com/B106913952R"],
+  ["pack-estudiante", "Pack KineCheck Estudiante", "$49.900", "https://pay.hotmart.com/Q106891608M"],
+];
+const RECUPERA_CHECKOUT = "https://pay.hotmart.com/P106806251E";
+const results = [];
+let failures = 0;
+
+function record(name, ok, detail) {
+  results.push({ name, status: ok ? "PASS" : "FAIL", detail });
+  if (!ok) failures += 1;
+  console.log(`${ok ? "✓" : "✗"} ${name}: ${detail}`);
+}
+
+async function read(path) {
+  return fs.readFile(path, "utf8");
+}
+
+async function sourceChecks() {
+  for (const [slug, name, price, checkout] of ACTIVE) {
+    const html = await read(`productos/${slug}/index.html`);
+    record(`Source ${name}`, html.includes(name) && html.includes(price) && html.includes(checkout) && html.includes("../../academy/"), "producto activo conserva precio, checkout canónico y acceso a Academy");
+  }
+
+  const recovery = await read("recupera/index.html");
+  const detail = await read("productos/kinecheck-recupera/index.html");
+  const combined = `${recovery}\n${detail}`;
+  record("Recupera pausado en fuente", /Próximamente/i.test(combined), "Recupera se presenta como Próximamente");
+  record("Recupera sin checkout activo", !combined.includes(RECUPERA_CHECKOUT), "no existe enlace Hotmart operativo de Recupera");
+  record("Recupera sin precio público activo", !/\$9\.990(?:\s*CLP)?/i.test(combined), "no se publica precio operativo de Recupera");
+
+  const academy = await read("academy/index.html");
+  record("Academy shell", academy.includes('id="login-view"') && academy.includes('id="kc-toast"') && academy.includes('id="kc-bottom-nav"'), "Academy conserva login, toast y navegación móvil");
+}
+
+async function get(path) {
+  const response = await fetch(`${BASE}${path}${path.includes("?") ? "&" : "?"}qa=post-privacy-${Date.now()}`, {
+    redirect: "follow",
+    headers: { "User-Agent": "KineCheck-QA-post-privacy/1.0", "Cache-Control": "no-cache" },
+  });
+  const text = await response.text();
+  return { response, text };
+}
+
+async function liveChecks() {
+  for (const [slug, name, price, checkout] of ACTIVE) {
+    try {
+      const { response, text } = await get(`/productos/${slug}/`);
+      record(`Live ${name}`, response.ok && text.includes(name) && text.includes(price) && text.includes(checkout), `${response.status} producto activo`);
+    } catch (error) {
+      record(`Live ${name}`, false, error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  try {
+    const { response, text } = await get("/recupera/");
+    record("Live Recupera Próximamente", response.ok && /Próximamente/i.test(text), `${response.status} Recupera pausado`);
+    record("Live Recupera sin comercio", !text.includes(RECUPERA_CHECKOUT) && !/\$9\.990(?:\s*CLP)?/i.test(text), "sin checkout ni precio operativo");
+  } catch (error) {
+    record("Live Recupera", false, error instanceof Error ? error.message : String(error));
+  }
+}
+
+await sourceChecks();
+await liveChecks();
+await fs.writeFile("qa-commercial-report.json", JSON.stringify({ generatedAt: new Date().toISOString(), baseUrl: BASE, failures, results }, null, 2));
+
+if (failures) {
+  console.error(`Commercial QA post-privacy failed with ${failures} blocking issue(s).`);
+  process.exit(1);
+}
+console.log("Commercial QA post-privacy passed.");

--- a/tests/launch-readiness-post-privacy.spec.mjs
+++ b/tests/launch-readiness-post-privacy.spec.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { chromium } from "playwright";
+
+const BASE = String(process.env.BASE_URL || "https://kinecheck.cl").replace(/\/$/, "");
+const VIEWPORTS = [
+  ["mobile", { width: 390, height: 844 }],
+  ["tablet", { width: 820, height: 1180 }],
+  ["desktop", { width: 1440, height: 1000 }],
+];
+const RECUPERA_CHECKOUT = "https://pay.hotmart.com/P106806251E";
+
+function normalize(text) {
+  return String(text || "").replace(/\s+/g, " ");
+}
+
+async function text(page) {
+  return normalize(await page.locator("body").innerText());
+}
+
+async function noOverflow(page, label) {
+  const box = await page.evaluate(() => ({ sw: document.documentElement.scrollWidth, cw: document.documentElement.clientWidth }));
+  assert.ok(box.sw <= box.cw + 3, `${label}: overflow horizontal ${box.sw}/${box.cw}`);
+}
+
+const browser = await chromium.launch({ headless: true });
+try {
+  for (const [device, viewport] of VIEWPORTS) {
+    const context = await browser.newContext({ viewport, locale: "es-CL", timezoneId: "America/Santiago" });
+    const page = await context.newPage();
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+    page.on("console", (message) => {
+      if (message.type() === "error" && !/favicon|metric-event|cloudflareinsights/i.test(`${message.text()} ${message.location().url || ""}`)) errors.push(message.text());
+    });
+
+    await page.goto(`${BASE}/?qa=post-privacy-${device}-${Date.now()}`, { waitUntil: "networkidle", timeout: 60000 });
+    const home = await text(page);
+    assert.ok(home.includes("KineCheck Clínico") && home.includes("KineCheck Estudiante") && home.includes("KineCheck Recupera"), `${device}: portada incompleta`);
+    await noOverflow(page, `${device}/home`);
+
+    await page.goto(`${BASE}/recupera/?qa=post-privacy-${device}-${Date.now()}`, { waitUntil: "networkidle", timeout: 60000 });
+    const recovery = await text(page);
+    assert.ok(/Próximamente/i.test(recovery), `${device}: Recupera no aparece como Próximamente`);
+    assert.ok(!recovery.includes("$9.990"), `${device}: Recupera vuelve a publicar precio operativo`);
+    const recoveryLinks = await page.locator("a").evaluateAll((nodes) => nodes.map((node) => node.href).filter(Boolean));
+    assert.ok(!recoveryLinks.includes(RECUPERA_CHECKOUT), `${device}: Recupera vuelve a exponer checkout Hotmart`);
+    await noOverflow(page, `${device}/recupera`);
+
+    await page.goto(`${BASE}/academy/?qa=post-privacy-${device}-${Date.now()}`, { waitUntil: "domcontentloaded", timeout: 60000 });
+    assert.equal(await page.locator("#login-view").count(), 1, `${device}: falta login de Academy`);
+    assert.equal(await page.locator("#kc-toast").count(), 1, `${device}: falta kc-toast`);
+    assert.equal(await page.locator("#kc-bottom-nav").count(), 1, `${device}: falta navegación móvil`);
+    assert.ok((await page.locator('[data-kc-view-link="biblioteca"]').count()) >= 1, `${device}: falta navegación Biblioteca`);
+    await noOverflow(page, `${device}/academy`);
+
+    assert.deepEqual(errors, [], `${device}: errores críticos de consola: ${errors.join(" | ")}`);
+    await context.close();
+  }
+} finally {
+  await browser.close();
+}
+
+console.log("Launch readiness post-privacy OK en móvil, tablet y escritorio.");

--- a/tests/platform-hardening-post-privacy.spec.mjs
+++ b/tests/platform-hardening-post-privacy.spec.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+const [health, ready, runtime, observability, academyHtml, academyBrand, academyRelay, academyV39, headers] = await Promise.all([
+  read("functions/api/health.js"),
+  read("functions/api/ready.js"),
+  read("assets/runtime-config.js"),
+  read("assets/observability.js"),
+  read("academy/index.html"),
+  read("academy/academy-brand-identity.js"),
+  read("academy/app-sso-relay.js"),
+  read("academy/academy-v39.js"),
+  read("_headers"),
+]);
+
+assert.match(health, /status:\s*"ok"/);
+assert.match(health, /cache-control/i);
+for (const token of ["publicSite", "academy", "auth", "licenseService", "sso", "503"]) assert.match(ready, new RegExp(token));
+
+assert.match(runtime, /KINECHECK_RUNTIME/);
+assert.match(runtime, /canonicalOrigin:\s*"https:\/\/kinecheck\.cl"/);
+assert.match(runtime, /health:\s*"\/api\/health"/);
+assert.match(runtime, /ready:\s*"\/api\/ready"/);
+
+assert.match(observability, /unhandledrejection/);
+assert.match(observability, /\[redacted\]/);
+assert.match(observability, /sessionStorage/);
+assert.doesNotMatch(observability, /localStorage/);
+
+// Contrato real de Academy posterior al hardening de privacidad.
+for (const script of ["academy-brand-identity.js", "academy-open-v6.js", "academy-owned-native-bridge-v1.js"]) {
+  assert.match(academyHtml, new RegExp(script.replace(".", "\\.")));
+}
+assert.match(academyHtml, /id="kc-toast"/);
+assert.match(academyHtml, /id="kc-bottom-nav"/);
+assert.match(academyHtml, /data-kc-view-link="biblioteca"/);
+
+// Recupera debe permanecer visible como producto pausado, nunca como flujo operativo.
+assert.match(academyBrand, /slug:\s*"kinecheck-recupera"/);
+assert.match(academyBrand, /Próximamente/);
+assert.match(academyBrand, /Acceso bloqueado/);
+assert.doesNotMatch(academyBrand, /P106806251E/);
+
+// Estudiante conserva POST SSO; Recupera no puede entrar al relay operativo.
+assert.match(academyV39, /method\s*=\s*["']post["']/i);
+assert.match(academyV39, /submit\(\)/);
+assert.match(academyRelay, /kinecheck-estudiante/);
+assert.doesNotMatch(academyRelay, /new Set\([^)]*["']kinecheck-recupera["']/s);
+
+assert.match(headers, /\/academy\/\*/);
+assert.match(headers, /X-Robots-Tag:\s*noindex, nofollow/);
+
+console.log("KineCheck platform hardening post-privacy OK: Academy, SSO Estudiante, Recupera pausado y controles de privacidad alineados con producción.");


### PR DESCRIPTION
Actualiza los cuatro contratos de CI que seguían evaluando el estado anterior de KineCheck tras el hardening verificado en producción.

Cambios principales:
- Recupera se valida como `Próximamente`, sin precio ni checkout operativo.
- QA comercial conserva validación de los siete productos activos y añade rechazo explícito del comercio de Recupera.
- QA pública multidispositivo valida el estado post-privacy en móvil, tablet y escritorio.
- Platform hardening deja de exigir el refactor excluido de `runtime-config.js` dentro de Academy y valida el shell productivo actual, `#kc-toast`, `#kc-bottom-nav`, SSO Estudiante y bloqueo de Recupera.
- Mi KineCheck mantiene roles, puerta única y estado pausado de Recupera.

No modifica Supabase, apps.kinecheck.cl, DNS, Hotmart, precios/Product IDs, datos de usuarios ni producción directamente.

Base esperada: `882b54c84af8368ff64695d33880d41ef377d9fb`.