### PR TITLE
Sprint 1 P1: clarify beta access and pause Recupera recruitment

### DIFF
--- a/.github/workflows/validate-beta-onboarding.yml
+++ b/.github/workflows/validate-beta-onboarding.yml
@@ -1,0 +1,32 @@
+name: Validate Beta Onboarding
+
+on:
+  pull_request:
+    paths:
+      - 'beta/**'
+      - 'tests/beta-onboarding-regression.test.mjs'
+      - '.github/workflows/validate-beta-onboarding.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'beta/**'
+      - 'tests/beta-onboarding-regression.test.mjs'
+      - '.github/workflows/validate-beta-onboarding.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  beta-onboarding:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Check beta script syntax
+        run: node --check beta/beta.js
+      - name: Validate beta onboarding contract
+        run: node --test tests/beta-onboarding-regression.test.mjs

--- a/beta/beta.js
+++ b/beta/beta.js
@@ -13,6 +13,48 @@
   const form = document.querySelector("#beta-form");
   const button = document.querySelector("#beta-submit");
   const message = document.querySelector("#beta-message");
+  const PAUSED_PRODUCT = "kinecheck-recupera";
+  const PAUSED_ROLE = "patient";
+  const BETA_ACCESS_COPY = "Si eres seleccionado, KineCheck te asignará el acceso temporal de prueba. No necesitas comprar un producto para participar en la beta.";
+
+  function applyCurrentBetaEligibility() {
+    const productSelect = document.querySelector("#productInterest");
+    productSelect?.querySelector(`option[value="${PAUSED_PRODUCT}"]`)?.remove();
+    if (productSelect?.value === PAUSED_PRODUCT) productSelect.value = "";
+
+    const roleSelect = document.querySelector("#role");
+    roleSelect?.querySelector(`option[value="${PAUSED_ROLE}"]`)?.remove();
+    if (roleSelect?.value === PAUSED_ROLE) roleSelect.value = "";
+
+    document.querySelectorAll(".track").forEach((track) => {
+      const title = String(track.querySelector("h3")?.textContent || "").trim();
+      if (title === "Personas en recuperación") track.remove();
+    });
+
+    document.querySelectorAll(".section-heading h2").forEach((heading) => {
+      if (heading.textContent?.includes("Cuatro miradas")) {
+        heading.textContent = heading.textContent.replace("Cuatro miradas", "Tres miradas");
+      }
+    });
+
+    const heroCard = document.querySelector(".hero-card .check-list");
+    if (heroCard && !heroCard.querySelector("[data-beta-no-purchase]")) {
+      const item = document.createElement("div");
+      item.dataset.betaNoPurchase = "true";
+      item.innerHTML = `<b>✓</b><span>${BETA_ACCESS_COPY}</span>`;
+      heroCard.appendChild(item);
+    }
+
+    const formCopy = document.querySelector(".form-copy");
+    if (formCopy && !formCopy.querySelector("[data-beta-access-note]")) {
+      const note = document.createElement("p");
+      note.dataset.betaAccessNote = "true";
+      note.textContent = BETA_ACCESS_COPY;
+      formCopy.appendChild(note);
+    }
+  }
+
+  applyCurrentBetaEligibility();
 
   function setMessage(text, error = false) {
     message.textContent = text;
@@ -39,6 +81,11 @@
       consentContact: data.get("consentContact") === "on",
       company: String(data.get("company") || ""),
     };
+
+    if (payload.productInterest === PAUSED_PRODUCT || payload.role === PAUSED_ROLE) {
+      setMessage("Esta convocatoria beta no está aceptando pruebas de KineCheck Recupera mientras el producto permanece Próximamente.", true);
+      return;
+    }
 
     button.disabled = true;
     button.textContent = "Enviando postulación…";

--- a/tests/beta-onboarding-regression.test.mjs
+++ b/tests/beta-onboarding-regression.test.mjs
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const betaJs = await readFile(new URL("../beta/beta.js", import.meta.url), "utf8");
+const betaHtml = await readFile(new URL("../beta/index.html", import.meta.url), "utf8");
+
+test("beta declara acceso temporal sin compra", () => {
+  assert.match(betaJs, /No necesitas comprar un producto para participar en la beta/);
+  assert.match(betaJs, /KineCheck te asignará el acceso temporal de prueba/);
+  assert.match(betaHtml, /beta\.js/);
+});
+
+test("Recupera y perfil paciente quedan fuera de la convocatoria activa", () => {
+  assert.match(betaJs, /PAUSED_PRODUCT = "kinecheck-recupera"/);
+  assert.match(betaJs, /PAUSED_ROLE = "patient"/);
+  assert.match(betaJs, /querySelector\(`option\[value=/);
+  assert.match(betaJs, /Personas en recuperación/);
+  assert.match(betaJs, /permanece Próximamente/);
+});
+
+test("el submit rechaza valores legacy pausados antes de enviar", () => {
+  assert.match(betaJs, /payload\.productInterest === PAUSED_PRODUCT/);
+  assert.match(betaJs, /payload\.role === PAUSED_ROLE/);
+  const guardIndex = betaJs.indexOf("payload.productInterest === PAUSED_PRODUCT");
+  const fetchIndex = betaJs.indexOf("await fetch(ENDPOINT");
+  assert.ok(guardIndex > 0 && fetchIndex > guardIndex, "el guard debe ejecutarse antes del POST de postulación");
+});


### PR DESCRIPTION
Resuelve TF-007 en la convocatoria beta actual.

Cambios:
- declara explícitamente que los seleccionados no necesitan comprar un producto para participar;
- aclara que KineCheck asigna el acceso temporal de prueba;
- retira dinámicamente Recupera y el perfil de persona en recuperación de la convocatoria mientras Recupera permanece `Próximamente`;
- rechaza valores legacy `patient`/`kinecheck-recupera` antes del POST de postulación;
- añade contrato de regresión y CI dedicado.

No modifica Hotmart, precios, Product IDs, Supabase, DNS, `apps.kinecheck.cl` ni datos de usuarios.