### PR TITLE
Sprint 1 P1: define privacy-minimal beta activation funnel

### DIFF
--- a/docs/testing/BETA_FUNNEL_REPORT_TEMPLATE.md
+++ b/docs/testing/BETA_FUNNEL_REPORT_TEMPLATE.md
@@ -1,0 +1,58 @@
+# Reporte agregado de activación beta
+
+> Plantilla de Sprint 1. No incluir nombres, correos, teléfonos, RUT, tokens ni contenido clínico.
+
+## Cohorte
+- Cohorte:
+- Periodo observado:
+- Productos incluidos:
+- Dispositivos considerados:
+
+## Embudo
+| Etapa | Conteo con evidencia | % sobre invitados | Observación objetiva |
+|---|---:|---:|---|
+| `tester_invited` |  | 100% | Invitaciones registradas |
+| `account_created` |  |  | Cuentas creadas confirmadas |
+| `license_activated` |  |  | Licencias temporales activadas |
+| `academy_opened` |  |  | Apertura de Academy confirmada |
+| `product_opened` |  |  | Producto asignado abierto |
+| `first_activity` |  |  | Primera actividad/tarea completada |
+| `return_session` |  |  | Evidencia de una sesión posterior |
+
+## Fricciones observadas
+Registrar únicamente hechos comprobables y códigos controlados. Ejemplos:
+- `ACCESS_EXPIRED_FALSE_POSITIVE`
+- `SSO_OPEN_FAILED`
+- `BUTTON_NO_ACTION`
+- `ONBOARDING_PURCHASE_CONFUSION`
+- `LAYOUT_OVERLAP`
+- `LOW_CONTRAST`
+
+No escribir una causa si no existe evidencia. Ejemplo correcto: “3 invitados sin evidencia de `account_created`”. Ejemplo incorrecto: “3 invitados no estaban interesados”.
+
+## Incidencias relacionadas
+- TF-001:
+- TF-002:
+- TF-003:
+- TF-004:
+- TF-005:
+- TF-006:
+- TF-007:
+- TF-008:
+
+## Resultado del periodo
+- Fricción principal comprobada:
+- Cambio aplicado:
+- Resultado después del cambio:
+- Próxima hipótesis a probar:
+
+## Evidencia suficiente para validación temprana
+Reportar por separado:
+- número de invitados;
+- número de activados;
+- número que llegó a primer uso;
+- número que retornó;
+- fricciones reproducidas;
+- fricciones corregidas y verificadas.
+
+No describir la beta como “mercado validado” únicamente por invitaciones, accesos o comentarios aislados.

--- a/docs/testing/TESTER_EVENT_SCHEMA.md
+++ b/docs/testing/TESTER_EVENT_SCHEMA.md
@@ -1,0 +1,46 @@
+# Tester event schema — Sprint 1
+
+## Objetivo
+Medir activación y retorno de la beta sin inferir causas de inactividad y sin almacenar contenido clínico o identificadores personales dentro de los eventos.
+
+## Embudo mínimo
+1. `tester_invited`
+2. `account_created`
+3. `license_activated`
+4. `academy_opened`
+5. `product_opened`
+6. `first_activity`
+7. `return_session`
+
+## Campos permitidos
+- `event_name`: uno de los siete eventos definidos.
+- `occurred_at`: fecha/hora del evento.
+- `cohort`: identificador general de cohorte, por ejemplo `beta-2026-08`.
+- `role`: `student`, `professional`, `teacher` u otro perfil aprobado para la beta activa.
+- `product_slug`: slug del producto probado cuando corresponda.
+- `device_class`: `mobile`, `desktop` o `both`.
+- `result`: `success`, `blocked` o `error`.
+- `error_code`: código técnico controlado, sin texto libre ni tokens.
+
+## Datos prohibidos
+No registrar en este esquema:
+- nombres o apellidos;
+- RUT;
+- correos o teléfonos;
+- contraseñas, access tokens o códigos de compra;
+- nombres o datos de pacientes;
+- texto libre de anamnesis, casos o contenidos clínicos;
+- fotografías o documentos clínicos;
+- números de ficha;
+- diagnósticos o información de salud individual.
+
+## Método inicial autorizado para Sprint 1
+Mientras no exista una autorización separada para instrumentación persistente o analítica externa, el seguimiento del Sprint 1 se realizará mediante **conteos agregados y revisión manual de estados**, sin almacenar nuevos identificadores personales en el repositorio.
+
+Las fuentes válidas para completar el reporte son evidencia ya existente del piloto, resultados de pruebas técnicas y conteos agregados proporcionados por el responsable de la beta. No se debe inferir una causa cuando un participante no avanza de etapa.
+
+## Interpretación
+Un abandono entre dos etapas significa únicamente que no existe evidencia de la etapa siguiente. No equivale por sí mismo a desinterés, error de producto, falta de tiempo, problema de licencia u otra causa.
+
+## Instrumentación futura
+Cualquier incorporación de analítica externa, persistencia nueva, cambios en Supabase o asociación de eventos a una persona requiere revisión y autorización separada antes de implementarse.


### PR DESCRIPTION
Avanza TF-008 sin instrumentar analítica externa ni persistencia nueva.

Incluye:
- esquema mínimo de eventos del embudo beta;
- campos permitidos y datos prohibidos;
- método inicial basado en conteos agregados y revisión manual;
- regla explícita de no inferir causas de inactividad;
- plantilla de reporte agregado para invitados, activados, primer uso y retorno.

No modifica código productivo, Supabase, Hotmart, DNS, precios, Product IDs ni datos de usuarios. Cualquier instrumentación persistente futura queda sujeta a autorización separada.