### PR TITLE
Sprint 1 P2: lock owner and beta role separation

### DIFF
--- a/.github/workflows/validate-role-separation.yml
+++ b/.github/workflows/validate-role-separation.yml
@@ -1,0 +1,33 @@
+name: Validate Owner and Beta Role Separation
+
+on:
+  pull_request:
+    paths:
+      - 'academy/academy-v39.js'
+      - 'watermark.js'
+      - 'tests/role-separation-regression.test.mjs'
+      - '.github/workflows/validate-role-separation.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'academy/academy-v39.js'
+      - 'watermark.js'
+      - 'tests/role-separation-regression.test.mjs'
+      - '.github/workflows/validate-role-separation.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  role-separation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: node --check academy/academy-v39.js
+      - run: node --check watermark.js
+      - run: node --test tests/role-separation-regression.test.mjs

--- a/tests/role-separation-regression.test.mjs
+++ b/tests/role-separation-regression.test.mjs
@@ -13,10 +13,7 @@ function blockBetween(source, start, end) {
 }
 
 test("tester beta nunca activa ownerMode por la lógica de presentación", () => {
-  const block = blockBetween(academy, "function updateAccountPresentation(session)", "function renderProfile");
-  assert.match(block, /ownerMode = isOwnerEmail\(userEmail\)/);
-  assert.match(block, /betaState = getBetaState\(session\)/);
-  assert.match(block, /betaMode = !ownerMode && betaState\.active/);
+  assert.match(academy, /function updateAccountPresentation\(session\)[\s\S]*?ownerMode = isOwnerEmail\(userEmail\)[\s\S]*?betaState = getBetaState\(session\)[\s\S]*?betaMode = !ownerMode && betaState\.active/);
 });
 
 test("badges distinguen propietario, prueba y licencia normal", () => {

--- a/tests/role-separation-regression.test.mjs
+++ b/tests/role-separation-regression.test.mjs
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const academy = await readFile(new URL("../academy/academy-v39.js", import.meta.url), "utf8");
+const watermark = await readFile(new URL("../watermark.js", import.meta.url), "utf8");
+
+function blockBetween(source, start, end) {
+  const a = source.indexOf(start);
+  const b = source.indexOf(end, a + start.length);
+  assert.ok(a >= 0 && b > a, `no se encontró bloque ${start}`);
+  return source.slice(a, b);
+}
+
+test("tester beta nunca activa ownerMode por la lógica de presentación", () => {
+  const block = blockBetween(academy, "function updateAccountPresentation(session)", "function renderProfile");
+  assert.match(block, /ownerMode = isOwnerEmail\(userEmail\)/);
+  assert.match(block, /betaState = getBetaState\(session\)/);
+  assert.match(block, /betaMode = !ownerMode && betaState\.active/);
+});
+
+test("badges distinguen propietario, prueba y licencia normal", () => {
+  const block = blockBetween(academy, "function accessBadge(access)", "function courseTypeLabel");
+  assert.match(block, /access === "owned" && ownerMode/);
+  assert.match(block, /return "Acceso propietario"/);
+  assert.match(block, /access === "owned" && betaMode/);
+  assert.match(block, /Prueba/);
+  assert.match(block, /return "Disponible"/);
+});
+
+test("marca de agua sólo acepta etiquetas PROPIETARIO o PRUEBA", () => {
+  assert.match(watermark, /\["PROPIETARIO", "PRUEBA"\]\.includes/);
+  assert.match(academy, /accessLabel: ownerMode \? "PROPIETARIO" : \(betaMode \? "PRUEBA" : ""\)/);
+});
+
+test("betaMode queda subordinado a !ownerMode también en apertura de producto", () => {
+  const matches = academy.match(/betaMode = !ownerMode && betaState\.active/g) || [];
+  assert.ok(matches.length >= 2, "la separación owner/beta debe aplicarse en presentación y apertura");
+});


### PR DESCRIPTION
Verifica TF-006 sin modificar accesos reales ni código productivo. Añade un contrato de regresión que exige que `ownerMode` dependa sólo de ownerEmails, que `betaMode` quede subordinado a `!ownerMode`, que los badges distingan propietario/prueba/licencia normal y que la marca de agua use `PROPIETARIO` o `PRUEBA` según el rol correcto.

No modifica Supabase, Hotmart, precios, Product IDs, DNS, apps.kinecheck.cl ni datos de usuarios.