### PR TITLE
Sprint 1 P1: implement privacy-safe TF-008 beta funnel

### DIFF
--- a/metrics-v1.js
+++ b/metrics-v1.js
@@ -7,6 +7,8 @@
   const ENDPOINT = "https://eqhcdclyeoapmqtlduwf.supabase.co/functions/v1/metric-event";
   const SESSION_KEY = "kc_metric_session_v1";
   const AUTH_SESSION_KEY = "kinecheck_secure_session_v1";
+  const COURSE_SESSION_PREFIX = "kinecheck_course_session_v2:";
+  const FUNNEL_ONCE_PREFIX = "kc_tf008_once:";
   const ALLOWED_PRODUCTS = new Set([
     "kinecheck-clinico",
     "kinecheck-estudiante",
@@ -58,27 +60,56 @@
     return ALLOWED_PRODUCTS.has(slug) ? slug : null;
   }
 
+  function parseSession(raw) {
+    try {
+      const session = JSON.parse(raw || "null");
+      return session?.access_token ? session : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function courseSessionRecord() {
+    try {
+      for (let index = 0; index < sessionStorage.length; index += 1) {
+        const key = sessionStorage.key(index) || "";
+        if (!key.startsWith(COURSE_SESSION_PREFIX)) continue;
+        const session = parseSession(sessionStorage.getItem(key));
+        const product = cleanProduct(key.slice(COURSE_SESSION_PREFIX.length));
+        if (session?.access_token && product) return { session, product };
+      }
+    } catch {
+      // Storage puede estar restringido; las métricas no deben interrumpir la aplicación.
+    }
+    return null;
+  }
+
   function authAccessToken() {
     try {
       const session = window.KINECHECK_ACADEMY_SESSION?.get?.();
       if (session?.access_token) return String(session.access_token);
     } catch {
-      // Fallback al storage compartido de Academy.
+      // Fallback a storages compartidos.
     }
 
     try {
-      const session = JSON.parse(localStorage.getItem(AUTH_SESSION_KEY) || "null");
-      return session?.access_token ? String(session.access_token) : null;
+      const session = parseSession(localStorage.getItem(AUTH_SESSION_KEY));
+      if (session?.access_token) return String(session.access_token);
     } catch {
-      return null;
+      // Continuar al storage de curso.
     }
+
+    return courseSessionRecord()?.session?.access_token
+      ? String(courseSessionRecord().session.access_token)
+      : null;
   }
 
   function send(eventName, options = {}) {
     const payload = {
       eventId: uuid(),
       eventName,
-      path: `${location.pathname}${location.search}`.slice(0, 300),
+      // Privacidad TF-008: nunca enviar query string ni hash en métricas.
+      path: String(location.pathname || "/").slice(0, 300),
       productSlug: cleanProduct(options.productSlug),
       sessionId: sessionId(),
       referrerHost: referrerHost(),
@@ -90,18 +121,43 @@
     const token = authAccessToken();
     if (token) headers.Authorization = `Bearer ${token}`;
 
-    fetch(ENDPOINT, {
+    return fetch(ENDPOINT, {
       method: "POST",
       headers,
       body: JSON.stringify(payload),
       keepalive: true,
       credentials: "omit",
-    }).catch(() => {});
+    }).catch(() => null);
   }
 
   function currentProduct() {
     const params = new URLSearchParams(location.search);
-    return cleanProduct(params.get("producto") || params.get("course"));
+    const fromQuery = cleanProduct(params.get("producto") || params.get("course"));
+    if (fromQuery) return fromQuery;
+
+    const fromDom = cleanProduct(
+      document.body?.getAttribute("data-course")
+      || document.documentElement?.getAttribute("data-course")
+      || document.querySelector("[data-course]")?.getAttribute("data-course"),
+    );
+    if (fromDom) return fromDom;
+
+    return courseSessionRecord()?.product || null;
+  }
+
+  function onceKey(eventName, product = "") {
+    return `${FUNNEL_ONCE_PREFIX}${eventName}:${product || "global"}:${location.pathname}`;
+  }
+
+  function markOnce(eventName, product = "") {
+    try {
+      const key = onceKey(eventName, product);
+      if (sessionStorage.getItem(key) === "1") return false;
+      sessionStorage.setItem(key, "1");
+      return true;
+    } catch {
+      return true;
+    }
   }
 
   function initialEvent() {
@@ -136,8 +192,57 @@
     }
   }
 
+  function instrumentAuthenticatedAcademyOpen() {
+    if (!location.pathname.startsWith("/academy/")) return;
+    let attempts = 0;
+    const timer = window.setInterval(() => {
+      attempts += 1;
+      if (authAccessToken()) {
+        window.clearInterval(timer);
+        if (markOnce("academy_opened")) send("academy_opened");
+        return;
+      }
+      if (attempts >= 50) window.clearInterval(timer);
+    }, 400);
+  }
+
+  function activityRoot() {
+    return document.querySelector("#root:not([hidden]), #app-view:not([hidden]), main") || document.body;
+  }
+
+  function instrumentAuthenticatedProductUse() {
+    if (location.pathname.startsWith("/academy/")) return;
+    let attempts = 0;
+    const timer = window.setInterval(() => {
+      attempts += 1;
+      const product = currentProduct();
+      const token = authAccessToken();
+      const root = activityRoot();
+      const explicitRoot = document.querySelector("#root");
+      const ready = !explicitRoot || !explicitRoot.hidden;
+
+      if (product && token && root && ready) {
+        window.clearInterval(timer);
+        if (markOnce("product_opened", product)) send("product_opened", { productSlug: product });
+
+        let activitySent = false;
+        const recordActivity = (event) => {
+          if (activitySent || event?.isTrusted === false) return;
+          activitySent = true;
+          if (markOnce("first_activity", product)) send("first_activity", { productSlug: product });
+          ["pointerdown", "keydown", "input", "change"].forEach((name) => root.removeEventListener(name, recordActivity, true));
+        };
+        ["pointerdown", "keydown", "input", "change"].forEach((name) => root.addEventListener(name, recordActivity, { capture: true, passive: true }));
+        return;
+      }
+
+      if (attempts >= 75) window.clearInterval(timer);
+    }, 400);
+  }
+
   // El bridge de Academy captura en window y puede detener propagación antes de document.
-  // Escuchar aquí garantiza que los toques de tarjetas proxy queden observables.
+  // Estos eventos históricos siguen siendo útiles como intención, pero no sustituyen
+  // los estados autenticados TF-008 academy_opened/product_opened.
   window.addEventListener("click", (event) => {
     const target = event.target instanceof Element ? event.target.closest("a,button") : null;
     if (!target) return;
@@ -175,11 +280,13 @@
 
   window.KINECHECK_METRIC = (eventName, options = {}) => send(String(eventName || ""), options);
 
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", initialEvent, { once: true });
-    document.addEventListener("DOMContentLoaded", cleanAcademyTrackingParams, { once: true });
-  } else {
+  function init() {
     initialEvent();
     cleanAcademyTrackingParams();
+    instrumentAuthenticatedAcademyOpen();
+    instrumentAuthenticatedProductUse();
   }
+
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init, { once: true });
+  else init();
 })();

--- a/supabase/functions/metric-event/index.ts
+++ b/supabase/functions/metric-event/index.ts
@@ -1,0 +1,245 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const allowedOrigins = new Set([
+  "https://kinecheck.cl",
+  "https://www.kinecheck.cl",
+]);
+
+const allowedEvents = new Set([
+  "page_view",
+  "product_view",
+  "checkout_start",
+  "academy_open",
+  "beta_view",
+  "beta_submit_success",
+  "support_view",
+  "support_submit_success",
+  "platform_login_view",
+  "platform_login_success",
+  "course_open",
+  "academy_opened",
+  "product_opened",
+  "first_activity",
+]);
+
+const authenticatedFunnelEvents = new Set([
+  "academy_opened",
+  "product_opened",
+  "first_activity",
+]);
+
+const allowedProducts = new Set([
+  "kinecheck-clinico",
+  "kinecheck-estudiante",
+  "kinecheck-recupera",
+  "comunicacion-clinica",
+  "mas-alla-del-dolor",
+  "evidencia-aplicada",
+  "traumatologia-ortopedia-clinica",
+  "pack-estudiante",
+]);
+
+function cors(origin: string | null) {
+  const selected = origin && allowedOrigins.has(origin) ? origin : "https://kinecheck.cl";
+  return {
+    "Access-Control-Allow-Origin": selected,
+    "Access-Control-Allow-Headers": "authorization, content-type",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Vary": "Origin",
+    "Cache-Control": "no-store",
+  };
+}
+
+function json(origin: string | null, payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...cors(origin), "Content-Type": "application/json; charset=utf-8" },
+  });
+}
+
+function clean(value: unknown, max: number) {
+  return String(value ?? "").trim().replace(/\s+/g, " ").slice(0, max);
+}
+
+function isUuid(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function cleanMetadata(value: unknown) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const source = value as Record<string, unknown>;
+  const output: Record<string, string | number | boolean> = {};
+  for (const [key, raw] of Object.entries(source).slice(0, 8)) {
+    const safeKey = clean(key, 40).replace(/[^a-zA-Z0-9_-]/g, "");
+    if (!safeKey) continue;
+    if (typeof raw === "boolean" || typeof raw === "number") output[safeKey] = raw;
+    else output[safeKey] = clean(raw, 120);
+  }
+  return output;
+}
+
+function cleanPath(value: unknown) {
+  const raw = clean(value, 300);
+  try {
+    const url = new URL(raw, "https://kinecheck.cl");
+    return clean(url.pathname || "/", 300);
+  } catch {
+    return raw.split(/[?#]/, 1)[0] || "/";
+  }
+}
+
+function isQaPath(path: string) {
+  try {
+    const url = new URL(path, "https://kinecheck.cl");
+    return url.searchParams.has("qa");
+  } catch {
+    return /(?:\?|&)qa=/i.test(path);
+  }
+}
+
+function bearerToken(req: Request) {
+  const authorization = req.headers.get("Authorization") || "";
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1].trim() : null;
+}
+
+function chileDateKey(value: string | Date) {
+  const date = value instanceof Date ? value : new Date(value);
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/Santiago",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+}
+
+Deno.serve(async (req: Request) => {
+  const origin = req.headers.get("Origin");
+
+  if (req.method === "OPTIONS") return new Response("ok", { headers: cors(origin) });
+  if (req.method !== "POST") return json(origin, { message: "Método no permitido." }, 405);
+  if (!origin || !allowedOrigins.has(origin)) return json(origin, { message: "Origen no autorizado." }, 403);
+
+  const contentLength = Number(req.headers.get("content-length") || 0);
+  if (contentLength > 8_000) return json(origin, { message: "Solicitud demasiado extensa." }, 413);
+
+  const body = await req.json().catch(() => null);
+  if (!body || typeof body !== "object") return json(origin, { message: "Solicitud inválida." }, 400);
+
+  const eventId = clean((body as any).eventId, 36).toLowerCase();
+  const eventName = clean((body as any).eventName, 40);
+  const rawPath = clean((body as any).path, 300);
+  const path = cleanPath(rawPath);
+  const productSlug = clean((body as any).productSlug, 80) || null;
+  const sessionId = clean((body as any).sessionId, 36).toLowerCase() || null;
+  const referrerHost = clean((body as any).referrerHost, 160) || null;
+  const deviceClass = clean((body as any).deviceClass, 20) || null;
+  const clientIsQa = (body as any).isQa === true;
+  const metadata = authenticatedFunnelEvents.has(eventName) ? {} : cleanMetadata((body as any).metadata);
+
+  if (!isUuid(eventId) || !allowedEvents.has(eventName) || !path.startsWith("/")) {
+    return json(origin, { message: "Evento inválido." }, 400);
+  }
+  if (productSlug && !allowedProducts.has(productSlug)) return json(origin, { message: "Producto inválido." }, 400);
+  if (sessionId && !isUuid(sessionId)) return json(origin, { message: "Sesión inválida." }, 400);
+  if (deviceClass && !["mobile", "tablet", "desktop"].includes(deviceClass)) {
+    return json(origin, { message: "Dispositivo inválido." }, 400);
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) return json(origin, { message: "Métricas no disponibles." }, 503);
+
+  const admin = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  let userId: string | null = null;
+  const token = bearerToken(req);
+  if (token) {
+    const { data, error } = await admin.auth.getUser(token);
+    if (!error && data?.user?.id) userId = data.user.id;
+  }
+
+  if (authenticatedFunnelEvents.has(eventName) && !userId) {
+    return json(origin, { message: "Evento autenticado requerido." }, 401);
+  }
+
+  if (sessionId) {
+    const since = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const { count, error: countError } = await admin
+      .from("kinecheck_public_events")
+      .select("id", { count: "exact", head: true })
+      .eq("session_id", sessionId)
+      .gte("occurred_at", since);
+    if (countError) {
+      console.error("metric-event count", countError.code);
+      return json(origin, { message: "No fue posible registrar la métrica." }, 500);
+    }
+    if ((count || 0) >= 200) return json(origin, { ok: true, limited: true });
+  }
+
+  const isQa = clientIsQa || isQaPath(rawPath);
+  const { error } = await admin.from("kinecheck_public_events").insert({
+    event_id: eventId,
+    event_name: eventName,
+    path,
+    product_slug: productSlug,
+    session_id: sessionId,
+    referrer_host: referrerHost,
+    device_class: deviceClass,
+    metadata,
+    user_id: userId,
+    is_qa: isQa,
+  });
+
+  if (error && error.code !== "23505") {
+    console.error("metric-event insert", error.code);
+    return json(origin, { message: "No fue posible registrar la métrica." }, 500);
+  }
+
+  let returnRecorded = false;
+  if (!isQa && userId && authenticatedFunnelEvents.has(eventName)) {
+    const { data: firstActivity } = await admin
+      .from("kinecheck_public_events")
+      .select("occurred_at")
+      .eq("user_id", userId)
+      .eq("event_name", "first_activity")
+      .eq("is_qa", false)
+      .order("occurred_at", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    if (firstActivity?.occurred_at && chileDateKey(firstActivity.occurred_at) < chileDateKey(new Date())) {
+      const todayStart = new Date();
+      todayStart.setUTCHours(0, 0, 0, 0);
+      const { count } = await admin
+        .from("kinecheck_public_events")
+        .select("id", { count: "exact", head: true })
+        .eq("user_id", userId)
+        .eq("event_name", "return_session")
+        .eq("is_qa", false)
+        .gte("occurred_at", todayStart.toISOString());
+
+      if ((count || 0) === 0) {
+        const { error: returnError } = await admin.from("kinecheck_public_events").insert({
+          event_id: crypto.randomUUID(),
+          event_name: "return_session",
+          path,
+          product_slug: productSlug,
+          session_id: sessionId,
+          referrer_host: null,
+          device_class: deviceClass,
+          metadata: {},
+          user_id: userId,
+          is_qa: false,
+        });
+        returnRecorded = !returnError;
+        if (returnError) console.error("metric-event return_session", returnError.code);
+      }
+    }
+  }
+
+  return json(origin, { ok: true, authenticated: Boolean(userId), returnRecorded });
+});

--- a/supabase/migrations/202608291450_tf008_beta_funnel_events.sql
+++ b/supabase/migrations/202608291450_tf008_beta_funnel_events.sql
@@ -1,0 +1,94 @@
+-- TF-008: eventos mínimos del embudo beta y reporte agregado.
+-- No almacena nombres, correos, RUT, teléfonos, texto clínico ni contenido de casos en eventos.
+
+alter table public.kinecheck_public_events
+  drop constraint if exists kinecheck_public_events_event_name_check;
+
+alter table public.kinecheck_public_events
+  add constraint kinecheck_public_events_event_name_check
+  check (event_name = any (array[
+    'page_view'::text,
+    'product_view'::text,
+    'checkout_start'::text,
+    'academy_open'::text,
+    'beta_view'::text,
+    'beta_submit_success'::text,
+    'support_view'::text,
+    'support_submit_success'::text,
+    'platform_login_view'::text,
+    'platform_login_success'::text,
+    'course_open'::text,
+    'academy_opened'::text,
+    'product_opened'::text,
+    'first_activity'::text,
+    'return_session'::text
+  ]));
+
+create or replace function public.kinecheck_beta_funnel_report()
+returns table (
+  invited bigint,
+  account_created bigint,
+  license_activated bigint,
+  academy_opened bigint,
+  product_opened bigint,
+  first_activity bigint,
+  return_session bigint
+)
+language sql
+security definer
+set search_path = public, auth
+as $$
+  with cohort as (
+    select distinct lower(ca.email) as email
+    from public.course_access ca
+    where ca.access_source = 'beta'
+  ),
+  cohort_users as (
+    select c.email, u.id as user_id
+    from cohort c
+    left join auth.users u on lower(u.email) = c.email
+  ),
+  stages as (
+    select
+      cu.email,
+      cu.user_id,
+      exists (
+        select 1 from public.course_access ca
+        where lower(ca.email) = cu.email
+          and ca.access_source = 'beta'
+          and ca.active = true
+      ) as has_license,
+      exists (
+        select 1 from public.kinecheck_public_events e
+        where e.user_id = cu.user_id and e.is_qa = false and e.event_name = 'academy_opened'
+      ) as has_academy,
+      exists (
+        select 1 from public.kinecheck_public_events e
+        where e.user_id = cu.user_id and e.is_qa = false and e.event_name = 'product_opened'
+      ) as has_product,
+      exists (
+        select 1 from public.kinecheck_public_events e
+        where e.user_id = cu.user_id and e.is_qa = false and e.event_name = 'first_activity'
+      ) as has_activity,
+      exists (
+        select 1 from public.kinecheck_public_events e
+        where e.user_id = cu.user_id and e.is_qa = false and e.event_name = 'return_session'
+      ) as has_return
+    from cohort_users cu
+  )
+  select
+    count(*)::bigint,
+    count(*) filter (where user_id is not null)::bigint,
+    count(*) filter (where has_license)::bigint,
+    count(*) filter (where has_academy)::bigint,
+    count(*) filter (where has_product)::bigint,
+    count(*) filter (where has_activity)::bigint,
+    count(*) filter (where has_return)::bigint
+  from stages;
+$$;
+
+comment on function public.kinecheck_beta_funnel_report() is
+  'TF-008: reporte agregado del embudo beta. La cohorte se define por course_access.access_source=beta; no devuelve identificadores personales.';
+
+revoke all on function public.kinecheck_beta_funnel_report() from public, anon, authenticated;
+grant execute on function public.kinecheck_beta_funnel_report() to service_role;


### PR DESCRIPTION
Implementa el método autorizado para TF-008 con minimización de datos.

Incluye:
- sanitización de rutas: las métricas nuevas no envían query string ni hash;
- reconocimiento de sesión autenticada también desde sesiones de curso;
- eventos autenticados `academy_opened`, `product_opened` y `first_activity`;
- generación server-side de `return_session` sólo en un día posterior al primer uso;
- rechazo de eventos de embudo si no existe usuario autenticado;
- metadata vacía para los eventos de embudo;
- restricción SQL actualizada y reporte agregado `kinecheck_beta_funnel_report()` accesible sólo por `service_role`;
- fuente administrativa de cohorte: accesos con `course_access.access_source = 'beta'`.

No agrega analítica externa y no registra nombre, correo, RUT, teléfono, texto clínico ni contenido de casos dentro de eventos de producto.

La migración y `metric-event` v3 fueron aplicados/desplegados en Supabase tras autorización explícita. El frontend queda sujeto a revisión/merge de este PR.

Refs #89