### PR TITLE
Blindaje: retirar autorización cliente de propietario y Beta

### DIFF
--- a/academy/config.js
+++ b/academy/config.js
@@ -3,9 +3,6 @@ window.KINECHECK_ACADEMY_CONFIG = Object.freeze({
   supabaseAnonKey: "sb_publishable_FTwhDZYCF3zf7W9rB7bFwQ_rF9Y7OX_",
   courseKeyFunction: "course-key",
   supportEmail: "soporte.kinecheck@gmail.com",
-  ownerEmails: ["emmanuelkine@gmail.com", "emmanuelkine+owner@gmail.com", "emmanuel_fox@hotmail.com"],
-  betaTesterEmails: ["emmanuelkine+beta@gmail.com"],
-  betaTrialDays: 5,
   appSso: Object.freeze({
     enabled: true,
     baseUrl: "https://apps.kinecheck.cl",


### PR DESCRIPTION
Cierra el bypass público identificado en #8 retirando de `academy/config.js` las listas `ownerEmails`, `betaTesterEmails` y `betaTrialDays`.

Con esas listas ausentes, Academy deja de conceder `hasFullAccess()` desde JavaScript del navegador y todos los productos activos pasan por la validación server-side existente de `course-key` contra `course_access`.

Validación previa en producción:
- `course-key` v20 está activo y exige JWT.
- propietario se resuelve server-side mediante `access_source='owner'`/`OWNER_ACCESS`;
- Beta se resuelve como acceso activo de `course_access`, con vencimiento `access_expires_at` y desactivación server-side;
- actualmente existen 37 filas activas de propietario para 4 cuentas;
- la marcha Beta está finalizada y no existen accesos Beta activos.

No se modifican usuarios, compras, webhooks ni reglas de licencia.

Antes de fusionar deben pasar los checks automáticos y conviene verificar que una cuenta propietaria mantiene sus accesos mediante `course-key`.

Refs #8.