### PR TITLE
Security: restrict status center snapshot execution

### DIFF
--- a/supabase/migrations/202608291545_restrict_status_center_snapshot_execution.sql
+++ b/supabase/migrations/202608291545_restrict_status_center_snapshot_execution.sql
@@ -1,0 +1,3 @@
+revoke all on function public.kinecheck_status_center_snapshot() from public;
+revoke execute on function public.kinecheck_status_center_snapshot() from anon, authenticated;
+grant execute on function public.kinecheck_status_center_snapshot() to service_role;


### PR DESCRIPTION
Go-live hardening aplicado también en producción Supabase.

Cambio:
- revoca `EXECUTE` de `public.kinecheck_status_center_snapshot()` a `PUBLIC`, `anon` y `authenticated`;
- mantiene ejecución sólo para `service_role`;
- evita que un RPC `SECURITY DEFINER` exponga por REST datos operativos de testers/actividad.

La migración ya fue aplicada en producción y este PR deja el cambio versionado y restaurable.

No modifica compras, licencias, webhooks ni usuarios.