### PR TITLE
QA: corregir payload del E2E autenticado

### DIFF
--- a/.github/workflows/qa-sso-authenticated-e2e.yml
+++ b/.github/workflows/qa-sso-authenticated-e2e.yml
@@ -52,6 +52,7 @@ jobs:
           set -euo pipefail
           access_token="$(cat "$RUNNER_TEMP/kc_access_token")"
           expires_at="$(cat "$RUNNER_TEMP/kc_expires_at")"
+          issued_at="$(date +%s)"
           headers="$RUNNER_TEMP/sso.headers"
           body="$RUNNER_TEMP/sso.body"
           status=$(curl -sS --max-time 30 -D "$headers" -o "$body" -w '%{http_code}' \
@@ -60,7 +61,9 @@ jobs:
             -H 'Content-Type: application/x-www-form-urlencoded' \
             --data-urlencode 'product=kinecheck-estudiante' \
             --data-urlencode "access_token=$access_token" \
-            --data-urlencode "expires_at=$expires_at")
+            --data-urlencode "expires_at=$expires_at" \
+            --data-urlencode "issued_at=$issued_at" \
+            --data-urlencode 'handoff_type=kinecheck-sso-v3-access-only')
           test "$status" = '303' || { echo "Expected 303, got HTTP $status" >&2; exit 1; }
 
           location=$(awk 'BEGIN{IGNORECASE=1} /^location:/{sub(/\r$/, "", $2); print $2; exit}' "$headers")


### PR DESCRIPTION
Corrige el workflow autenticado para enviar exactamente el mismo handoff que Academy: `product`, `access_token`, `expires_at`, `issued_at` y `handoff_type`. La primera ejecución autenticó correctamente en Supabase pero el SSO respondió 400 porque el probe omitía los dos últimos campos. No modifica producción, usuarios ni licencias.