### PR TITLE
Harden disaster recovery verification

### DIFF
--- a/.github/workflows/kinecheck-disaster-recovery-v2.yml
+++ b/.github/workflows/kinecheck-disaster-recovery-v2.yml
@@ -8,7 +8,15 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/kinecheck-disaster-recovery-v2.yml"
+      - "scripts/validate-disaster-recovery.mjs"
       - "docs/continuidad/plan-recuperacion-kinecheck.md"
+      - "docs/continuidad/recuperacion-servicios-administrados.md"
+  pull_request:
+    paths:
+      - ".github/workflows/kinecheck-disaster-recovery-v2.yml"
+      - "scripts/validate-disaster-recovery.mjs"
+      - "docs/continuidad/plan-recuperacion-kinecheck.md"
+      - "docs/continuidad/recuperacion-servicios-administrados.md"
 
 permissions:
   contents: read
@@ -18,7 +26,21 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  contract-check:
+    name: Validate disaster-recovery contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate workflow and recovery documentation
+        run: node scripts/validate-disaster-recovery.mjs
+
   backup-restore-verify:
+    name: Encrypted public-schema backup and PostgreSQL 17 restore
+    needs: contract-check
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     services:
@@ -62,6 +84,8 @@ jobs:
             echo "Configure both repository secrets before the external backup can run."
             exit 1
           fi
+          echo "::add-mask::${SUPABASE_DB_URL}"
+          echo "::add-mask::${BACKUP_ENCRYPTION_PASSPHRASE}"
 
       - name: Create public-schema database dump
         shell: bash
@@ -139,6 +163,10 @@ jobs:
             'feature_flags', (select count(*) from public.platform_feature_flags),
             'legal_acceptances', (select count(*) from public.kinecheck_legal_acceptances)
           )" > disaster-recovery/restored-counts.json
+          jq -e '
+            type == "object" and
+            ([.course_access, .product_grants, .purchases, .feature_flags, .legal_acceptances] | all(type == "number" and . >= 0))
+          ' disaster-recovery/restored-counts.json > /dev/null
 
       - name: Build recovery manifest
         shell: bash
@@ -160,18 +188,56 @@ jobs:
             "auth_users_included": false
           }
           EOF
+          jq -e '
+            .scope == "public_schema" and
+            .postgres_version == "17" and
+            .restore_validation == "passed" and
+            .storage_objects_included == false and
+            .auth_users_included == false and
+            (.dump_sha256 | test("^[0-9a-f]{64}$")) and
+            (.restored_counts | type == "object")
+          ' disaster-recovery/manifest.json > /dev/null
 
-      - name: Encrypt backup
+      - name: Encrypt and verify recovery package
         shell: bash
         run: |
           set -euo pipefail
+          verification_dump="${RUNNER_TEMP}/kinecheck-public.verify.dump"
+          cleanup_plaintext() {
+            rm -f \
+              disaster-recovery/kinecheck-public.dump \
+              disaster-recovery/kinecheck-public.dump.sha256 \
+              "$verification_dump"
+          }
+          trap cleanup_plaintext EXIT
+
+          expected_checksum=$(cut -d' ' -f1 disaster-recovery/kinecheck-public.dump.sha256)
           openssl enc -aes-256-cbc -salt -pbkdf2 -iter 250000 \
             -in disaster-recovery/kinecheck-public.dump \
             -out disaster-recovery/kinecheck-public.dump.enc \
             -pass env:BACKUP_ENCRYPTION_PASSPHRASE
           test -s disaster-recovery/kinecheck-public.dump.enc
+
+          openssl enc -d -aes-256-cbc -pbkdf2 -iter 250000 \
+            -in disaster-recovery/kinecheck-public.dump.enc \
+            -out "$verification_dump" \
+            -pass env:BACKUP_ENCRYPTION_PASSPHRASE
+          actual_checksum=$(sha256sum "$verification_dump" | cut -d' ' -f1)
+          test "$actual_checksum" = "$expected_checksum"
+          docker run --rm \
+            -v "${RUNNER_TEMP}:/verify:ro" \
+            postgres:17 \
+            pg_restore --list /verify/kinecheck-public.verify.dump > /dev/null
+
           sha256sum disaster-recovery/kinecheck-public.dump.enc > disaster-recovery/kinecheck-public.dump.enc.sha256
-          rm -f disaster-recovery/kinecheck-public.dump disaster-recovery/kinecheck-public.dump.sha256
+
+      - name: Confirm plaintext removal
+        shell: bash
+        run: |
+          set -euo pipefail
+          test ! -e disaster-recovery/kinecheck-public.dump
+          test ! -e disaster-recovery/kinecheck-public.dump.sha256
+          test ! -e "${RUNNER_TEMP}/kinecheck-public.verify.dump"
 
       - name: Upload encrypted recovery package
         uses: actions/upload-artifact@v4
@@ -192,7 +258,9 @@ jobs:
           {
             echo "## KineCheck Disaster Recovery"
             echo
-            if [ -f disaster-recovery/manifest.json ]; then
+            if [ -s disaster-recovery/manifest.json ] && \
+               [ -s disaster-recovery/kinecheck-public.dump.enc ] && \
+               [ -s disaster-recovery/kinecheck-public.dump.enc.sha256 ]; then
               echo "External encrypted database backup: **created**"
               echo
               echo "Temporary PostgreSQL restore: **passed**"
@@ -202,3 +270,12 @@ jobs:
               echo "Backup package was not created. Review the failed step and required repository secrets."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Remove plaintext recovery material
+        if: always()
+        shell: bash
+        run: |
+          rm -f \
+            disaster-recovery/kinecheck-public.dump \
+            disaster-recovery/kinecheck-public.dump.sha256 \
+            "${RUNNER_TEMP}/kinecheck-public.verify.dump"

--- a/docs/continuidad/inventario-edge-functions-2026-08-30.md
+++ b/docs/continuidad/inventario-edge-functions-2026-08-30.md
@@ -1,0 +1,54 @@
+# Inventario y regularización de Edge Functions — 30 de agosto de 2026
+
+Proyecto observado en modo de solo lectura: `eqhcdclyeoapmqtlduwf`.
+
+Producción informa 18 Edge Functions `ACTIVE`; ocho tienen fuente en `supabase/functions/` y diez no tienen fuente, referencia de consumidor ni historial Git local en este repositorio. No se descargó ni copió código desplegado, y no se leyeron valores de secretos.
+
+La finalidad de este inventario es recuperar trazabilidad, no recrear comportamiento por inferencia. Los campos de uso y criticidad que no tienen fuente se basan únicamente en el slug, `verify_jwt` y metadatos de despliegue; deben confirmarse con el propietario y la fuente original.
+
+## Funciones versionadas
+
+| Función | Fuente local |
+|---|---|
+| `automation-status` | `supabase/functions/automation-status/` |
+| `beta-apply` | `supabase/functions/beta-apply/` |
+| `course-key` | `supabase/functions/course-key/` |
+| `course-review` | `supabase/functions/course-review/` |
+| `evidence-hotmart-webhook` | `supabase/functions/evidence-hotmart-webhook/` |
+| `hotmart-webhook` | `supabase/functions/hotmart-webhook/` |
+| `metric-event` | `supabase/functions/metric-event/` |
+| `platform-context` | `supabase/functions/platform-context/` |
+
+## Funciones activas sin fuente versionada
+
+| Función | Versión observada | `verify_jwt` | Uso inferido; requiere confirmación | Criticidad provisional | Riesgo principal de recuperación |
+|---|---:|:---:|---|---|---|
+| `platform-login` | 1 | no | Entrada de autenticación de plataforma | Crítica | Pérdida de login o reconstrucción insegura de autenticación |
+| `pain-hotmart-webhook` | 2 | no | Eventos comerciales y licencias del producto de dolor | Crítica | Acceso incorrecto, duplicados o revocaciones perdidas |
+| `evidence-access` | 6 | sí | Resolución de acceso a Evidencia | Crítica | Denegación o concesión indebida de contenido licenciado |
+| `dolor-lumbar-course-key` | 1 | sí | Resolución de clave/acceso de Dolor Lumbar | Crítica | Pérdida o bypass del control de acceso |
+| `automation-control` | 1 | sí | Operaciones administrativas sobre automatizaciones | Alta | Acciones administrativas no recuperables o no autorizadas |
+| `beta-password-once` | 6 | sí | Emisión o consumo de credencial beta de un solo uso | Alta | Exposición o reutilización de credenciales temporales |
+| `student-semester-intake` | 1 | sí | Ingreso de datos del semestre de Estudiante | Alta | Pérdida de flujo y riesgo de privacidad/retención |
+| `evidence-content` | 9 | no | Entrega de contenido de Evidencia | Alta | Exposición de contenido; `verify_jwt=false` exige comprobar autenticación interna |
+| `pain-content` | 2 | no | Entrega de contenido del producto de dolor | Alta | Exposición de contenido; `verify_jwt=false` exige comprobar autenticación interna |
+| `support-request` | 2 | no | Recepción de solicitudes de soporte | Media | Abuso, spam o exposición de datos de contacto |
+
+`verify_jwt=false` no demuestra por sí solo una vulnerabilidad: webhooks y endpoints públicos pueden requerirlo. Sin fuente no se puede confirmar HOTTOK, firma, rate limit, autorización dentro del handler, minimización de datos, CORS ni redacción de logs; por eso estas funciones no deben reconstruirse o redesplegarse por semejanza con otros endpoints.
+
+## Plan de regularización seguro
+
+1. **Congelar sustituciones.** No sobrescribir, eliminar ni redesplegar estas diez funciones salvo una corrección P0/P1 con autorización y rollback preparado.
+2. **Asignar propietario.** Registrar responsable funcional, consumidores conocidos, datos tratados, evento de entrada, dependencias y secretos solo por nombre.
+3. **Localizar fuente autorizada.** Buscar en repositorios privados, proyectos locales del propietario, artifacts de CI y respaldos controlados. No copiar el cuerpo desde producción ni usar el editor desplegado como fuente.
+4. **Probar procedencia.** Para cada candidato registrar repositorio, commit, fecha, autor y huella reproducible. Si no puede vincularse de forma verificable con la función activa, mantenerla como fuente no recuperada.
+5. **Revisión de seguridad.** Antes de versionar comprobar autenticación interna, RLS, privilegios, idempotencia, rate limit, CORS, PII/logs, errores y manejo de secretos. Priorizar las cuatro funciones críticas y luego las que usan `verify_jwt=false`.
+6. **Versionar sin desplegar.** Incorporar la fuente comprobada mediante PR pequeño, con `supabase/config.toml`, dependencias fijadas, inventario de secretos por nombre y pruebas. La aceptación del PR no autoriza despliegue.
+7. **Validar sin recursos pagos.** Usar runtime local o un entorno existente expresamente autorizado. No crear branches/proyectos Supabase con costo.
+8. **Comparar contrato.** Verificar rutas, métodos, autenticación, códigos de estado y efectos con datos ficticios. No invocar webhooks comerciales reales ni alterar licencias.
+9. **Despliegue separado.** Solo con autorización explícita, fuente comprobada, backup, plan de rollback y smoke tests específicos. Conservar el `verify_jwt` observado hasta que una revisión funcional demuestre otro contrato.
+10. **Fuente irrecuperable.** Si no aparece evidencia suficiente, mantener el gap abierto y diseñar un reemplazo desde especificación aprobada en una iniciativa separada; nunca reconstruirlo a partir del nombre o de respuestas de producción.
+
+## Criterio de cierre de la brecha
+
+La diferencia 18/8 se cierra únicamente cuando las diez funciones cuentan con fuente autorizada y trazable, configuración versionada, inventario de secretos por nombre, pruebas reproducibles y procedimiento de despliegue/rollback. Un listado de metadatos o el hecho de que la función responda en producción no equivale a un respaldo recuperable.

--- a/docs/continuidad/plan-recuperacion-kinecheck.md
+++ b/docs/continuidad/plan-recuperacion-kinecheck.md
@@ -1,6 +1,6 @@
 # Plan de recuperación KineCheck
 
-Última actualización: 5 de agosto de 2026
+Última actualización: 30 de agosto de 2026
 
 ## Objetivo
 
@@ -16,8 +16,12 @@ El workflow `KineCheck Disaster Recovery v2`:
 4. Comprueba tablas y funciones críticas.
 5. Registra conteos restaurados y manifiesto técnico.
 6. Cifra el respaldo con AES-256-CBC, PBKDF2 y 250.000 iteraciones.
-7. Elimina el archivo sin cifrar antes de subir el artefacto.
-8. Conserva el paquete cifrado en GitHub Actions durante 30 días.
+7. Descifra una copia temporal, compara su SHA-256 con el dump original y verifica el catálogo con `pg_restore --list`.
+8. Valida la estructura JSON del manifiesto y los conteos restaurados.
+9. Elimina el dump y toda copia temporal sin cifrar antes de subir el artefacto.
+10. Conserva el paquete cifrado en GitHub Actions durante 30 días.
+
+Los eventos `push` y `pull_request` ejecutan únicamente el validador estático del contrato. El respaldo real se ejecuta solo por agenda o despacho manual, porque requiere secretos de producción.
 
 ## Secretos requeridos
 
@@ -38,6 +42,8 @@ La ejecución debe terminar en verde y el artefacto debe contener:
 - `restored-counts.json`
 
 El manifiesto debe indicar `restore_validation: passed`.
+
+Además, la ejecución debe demostrar que el archivo cifrado se descifra con la frase configurada, que conserva la huella del dump restaurado y que no se sube ningún archivo PostgreSQL sin cifrar.
 
 ## Restauración controlada
 
@@ -72,7 +78,15 @@ pg_restore --no-owner --no-acl --exit-on-error \
 - Configuración de DNS y cuenta de Cloudflare.
 - Configuración interna de productos y webhooks en Hotmart.
 
-Estos componentes requieren inventario y procedimientos separados.
+Estos componentes requieren inventario y procedimientos separados. El checklist vigente está en [Recuperación de servicios administrados](./recuperacion-servicios-administrados.md).
+
+## Estado y criterio de cierre de #10
+
+La restauración lógica interna ya fue verificada. El respaldo externo permanece bloqueado mientras no existan en GitHub Actions `SUPABASE_DB_URL` y `BACKUP_ENCRYPTION_PASSPHRASE`.
+
+La incidencia #10 no se puede cerrar hasta que exista una ejecución verde que genere el paquete cifrado, restaure el dump en PostgreSQL 17 y conserve sus artefactos, y hasta que los procedimientos separados de Storage y Auth hayan sido ejecutados con evidencia. Configurar los secretos requiere autorización del propietario; este plan no crea ni cambia credenciales.
+
+El respaldo del esquema `public` no contiene los binarios de Storage ni usuarios de Auth. Tampoco reemplaza el respaldo de Edge Functions, secretos por nombre, configuración de proveedores, DNS o Cloudflare.
 
 ## Frecuencia
 

--- a/docs/continuidad/recuperacion-servicios-administrados.md
+++ b/docs/continuidad/recuperacion-servicios-administrados.md
@@ -88,6 +88,8 @@ Diez funciones activas no tienen directorio fuente local verificado:
 
 Esta diferencia es una brecha de recuperación. Antes de declarar restaurabilidad integral se debe recuperar la fuente autorizada, revisarla para evitar secretos embebidos, versionarla y registrar la versión desplegada y su huella.
 
+El inventario de metadatos, clasificación provisional por uso/criticidad y plan de regularización sin copiar código productivo está en [Inventario y regularización de Edge Functions — 30 de agosto de 2026](./inventario-edge-functions-2026-08-30.md).
+
 Checklist:
 
 1. Comparar inventario de producción con `supabase/functions/`.

--- a/docs/continuidad/recuperacion-servicios-administrados.md
+++ b/docs/continuidad/recuperacion-servicios-administrados.md
@@ -1,0 +1,121 @@
+# Recuperación de servicios administrados de KineCheck
+
+Última verificación de inventario: 30 de agosto de 2026
+
+Este documento complementa el respaldo PostgreSQL del esquema `public`. Registra procedimientos y evidencia esperada; no contiene valores de secretos, tokens, contraseñas, datos de usuarios ni cadenas de conexión.
+
+## Reglas de seguridad
+
+- Trabajar primero en un entorno temporal autorizado. No crear ramas de base de datos, proyectos u otros recursos pagos sin autorización explícita.
+- Usar datos ficticios y el mínimo privilegio necesario.
+- Registrar nombres de secretos, versiones, huellas y conteos; nunca sus valores.
+- No restaurar producción sin respaldo previo, ventana aprobada y plan de reversión.
+- El dump de `public` no respalda binarios de Storage ni usuarios/configuración de Auth.
+
+## Storage
+
+Inventario leído de producción:
+
+- bucket privado `course-assets`;
+- 3 objetos registrados al momento de la revisión;
+- acceso público deshabilitado.
+
+Checklist de respaldo:
+
+1. Exportar el inventario con bucket, ruta, tamaño, tipo MIME, fecha y ETag o huella cuando esté disponible, sin publicar enlaces firmados.
+2. Copiar los objetos a almacenamiento cifrado, privado y separado de la cuenta productiva.
+3. Generar un manifiesto firmado o con SHA-256 por objeto y un conteo total.
+4. Confirmar que ningún objeto privado se vuelva público durante la copia.
+5. Conservar políticas, límites de tamaño y tipos MIME permitidos como configuración separada.
+
+Checklist de restauración:
+
+1. Crear un bucket privado temporal con la configuración documentada.
+2. Restaurar los objetos y comparar conteo, tamaño y huellas con el manifiesto.
+3. Probar acceso autorizado y denegación anónima con datos ficticios.
+4. Borrar el entorno temporal al terminar.
+
+Estado: inventario confirmado; copia binaria externa y restauración de integridad pendientes.
+
+## Auth
+
+No exportar contraseñas, tokens activos, sesiones ni metadatos innecesarios. La migración de usuarios de Auth es un procedimiento distinto del dump del esquema `public` y debe seguir la guía vigente de Supabase, considerando proveedores y claves JWT.
+
+Inventario manual requerido, sin valores sensibles:
+
+- proveedores habilitados y su modo de configuración;
+- Site URL y lista de Redirect URLs;
+- plantillas de correo y configuración SMTP;
+- política de contraseña, MFA, CAPTCHA y protección contra contraseñas filtradas;
+- dominios permitidos, tiempos de sesión y controles de registro;
+- hooks o integraciones de Auth;
+- conteos agregados mínimos para reconciliación, sin exportar credenciales.
+
+Prueba de recuperación:
+
+1. Reconstruir la configuración en un entorno temporal autorizado.
+2. Usar una cuenta ficticia nueva; no reutilizar contraseñas reales.
+3. Verificar alta, confirmación, login, renovación, logout y redirects.
+4. Confirmar que roles/licencias se resuelven desde las fuentes autorizadas y no desde datos inventados.
+
+Estado: inventario y simulacro manual pendientes. El advisor de seguridad mantiene la advertencia `Leaked Password Protection Disabled`; su activación requiere revisión y cambio explícito en Dashboard.
+
+## Edge Functions
+
+Producción informa 18 funciones activas. Ocho tienen fuente versionada en este repositorio:
+
+- `automation-status`
+- `beta-apply`
+- `course-key`
+- `course-review`
+- `evidence-hotmart-webhook`
+- `hotmart-webhook`
+- `metric-event`
+- `platform-context`
+
+Diez funciones activas no tienen directorio fuente local verificado:
+
+- `automation-control`
+- `beta-password-once`
+- `dolor-lumbar-course-key`
+- `evidence-access`
+- `evidence-content`
+- `pain-content`
+- `pain-hotmart-webhook`
+- `platform-login`
+- `student-semester-intake`
+- `support-request`
+
+Esta diferencia es una brecha de recuperación. Antes de declarar restaurabilidad integral se debe recuperar la fuente autorizada, revisarla para evitar secretos embebidos, versionarla y registrar la versión desplegada y su huella.
+
+Checklist:
+
+1. Comparar inventario de producción con `supabase/functions/`.
+2. Respaldar código fuente, configuración de verificación JWT y versión de runtime.
+3. Mantener los nombres de secretos requeridos en el inventario, nunca sus valores.
+4. Desplegar en entorno temporal y ejecutar pruebas de autorización, errores e idempotencia.
+5. Verificar que logs y respuestas no expongan PII, tokens ni cadenas de conexión.
+
+Los nombres observados en las ocho funciones versionadas son `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `HOTMART_HOTTOK`, `EVIDENCE_HOTMART_HOTTOK` y `EVIDENCE_HOTMART_PRODUCT_ID`. La lista completa de producción debe confirmarse desde el panel autorizado.
+
+## Secretos y configuración
+
+Mantener un inventario fuera del repositorio que contenga únicamente nombres de secretos, propietario, servicio consumidor, fecha de última rotación y procedimiento de recuperación. Los valores deben residir en un gestor seguro con acceso de emergencia auditado.
+
+Para GitHub Actions, el workflow v2 requiere los nombres de secretos `SUPABASE_DB_URL` y `BACKUP_ENCRYPTION_PASSPHRASE`. Ambos estaban ausentes al 30 de agosto de 2026. No registrar sus valores en logs, artifacts, issues ni documentación.
+
+## DNS y Cloudflare
+
+Checklist de evidencia, sin realizar cambios:
+
+1. Exportar o capturar el inventario de zonas, registros DNS, proxied/DNS-only, TTL y destino esperado.
+2. Registrar reglas de redirects, cache, WAF, certificados, Pages/Workers y dominio personalizado.
+3. Documentar registrador, contactos autorizados y procedimiento de acceso de emergencia.
+4. Comparar el dominio restaurado con una línea base aprobada antes de cambiar nameservers o registros.
+5. Verificar TLS, rutas públicas, SSO y ausencia de exposición del origen.
+
+Estado: procedimiento documentado; exportación y simulacro pendientes. Este trabajo no autoriza cambios de DNS ni Cloudflare.
+
+## Criterio de evidencia
+
+Cada simulacro debe registrar fecha, responsable, alcance, commit, versiones de servicios, manifiestos, conteos, huellas, resultados y limpieza final. El resultado válido es reproducible, no expone secretos y no depende de recursos productivos modificados durante la prueba.

--- a/docs/seguridad/checklist-administrativo.md
+++ b/docs/seguridad/checklist-administrativo.md
@@ -1,6 +1,6 @@
 # Checklist de seguridad administrativa KineCheck
 
-Última actualización: 5 de agosto de 2026
+Última actualización: 30 de agosto de 2026
 
 ## Controles técnicos ya implementados
 
@@ -75,6 +75,8 @@
 - Trimestral: cambiar secretos críticos cuando exista riesgo o exposición; probar recuperación de cuentas.
 - Inmediata: ante pérdida de dispositivo, correo comprometido, acceso inesperado o secreto expuesto.
 
-## Resultado de auditoría del 5 de agosto de 2026
+## Resultado de auditoría del 30 de agosto de 2026
 
 Supabase no reportó vulnerabilidades críticas de base de datos. El aviso de seguridad pendiente es la protección contra contraseñas filtradas desactivada. Los avisos informativos de RLS sin políticas corresponden a tablas privadas deliberadamente inaccesibles para usuarios `anon` y `authenticated`; no deben abrirse solo para eliminar el aviso.
+
+La evidencia por tabla, incluida la excepción de grants nominales de `evidence_library`, está documentada en [Supabase Advisors — 30 de agosto de 2026](./supabase-advisors-2026-08-30.md).

--- a/docs/seguridad/supabase-advisors-2026-08-30.md
+++ b/docs/seguridad/supabase-advisors-2026-08-30.md
@@ -1,0 +1,52 @@
+# Evidencia de Supabase Advisors — 30 de agosto de 2026
+
+Proyecto revisado: `eqhcdclyeoapmqtlduwf`.
+
+Esta evidencia es de solo lectura. No se cambiaron Auth, RLS, grants, datos, secretos ni configuración del proyecto.
+
+## Security Advisor
+
+Resultado observado:
+
+- 0 errores críticos;
+- 1 advertencia: `Leaked Password Protection Disabled`;
+- 16 avisos informativos: `RLS Enabled No Policy`.
+
+La protección contra contraseñas filtradas debe habilitarse desde Supabase Auth por un administrador autorizado. No existe en este trabajo autorización para cambiar Auth y no se asumirá un endpoint administrativo no verificado. Referencia: <https://supabase.com/docs/guides/auth/password-security#password-strength-and-leaked-password-protection>.
+
+## RLS Enabled No Policy
+
+Las siguientes tablas tienen RLS habilitado, cero políticas y ningún grant directo para los roles `anon` o `authenticated`; su acceso está deliberadamente reservado a procesos de servidor con privilegios controlados:
+
+- `beta_applications`
+- `hotmart_events`
+- `hotmart_product_grants`
+- `hotmart_purchases`
+- `hotmart_webhook_events`
+- `kinecheck_access_policy`
+- `kinecheck_automation_runs`
+- `kinecheck_daily_metrics`
+- `kinecheck_outbox`
+- `kinecheck_public_events`
+- `kinecheck_reconciliation_issues`
+- `kinecheck_restore_drills`
+- `kinecheck_support_requests`
+- `platform_login_limits`
+- `student_semester_responses`
+
+`evidence_library` también tiene RLS habilitado y cero políticas. Conserva grants nominales para `anon` y `authenticated`, pero la ausencia de políticas deniega filas a esos roles. Antes de cambiar esos grants se debe revisar el consumidor y probarlo; no se agrega una política permisiva únicamente para eliminar el aviso.
+
+Referencia del advisor: <https://supabase.com/docs/guides/database/database-linter?lint=0008_rls_enabled_no_policy>.
+
+## Performance Advisor
+
+Se observaron dos advertencias `Auth RLS Initialization Plan` en políticas de `course_access` y `course_content`, además de índices informados como no usados. Son hallazgos de rendimiento separados del alcance de recuperación y no justifican una modificación sin medición y pruebas específicas.
+
+No se eliminarán índices por una sola observación de “unused index” y no se reescribirán políticas de acceso dentro de este hardening de continuidad.
+
+## Seguimiento
+
+- Mantener `Leaked Password Protection Disabled` como pendiente administrativo.
+- Volver a ejecutar Security y Performance Advisors después de cambios DDL o de Auth.
+- Tratar un nuevo hallazgo `ERROR` o `WARN` de acceso como bloqueo hasta clasificar su impacto.
+- No cerrar el pendiente de seguridad solo porque las tablas service-only no exponen filas al cliente.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "scripts": {
     "test": "node --test tests/*.test.mjs",
-    "test:hotmart": "node --test tests/hotmart-access-regression.test.mjs"
+    "test:hotmart": "node --test tests/hotmart-access-regression.test.mjs",
+    "test:disaster-recovery": "node scripts/validate-disaster-recovery.mjs"
   },
   "devDependencies": {
     "@electric-sql/pglite": "0.5.4"

--- a/scripts/validate-disaster-recovery.mjs
+++ b/scripts/validate-disaster-recovery.mjs
@@ -3,10 +3,11 @@ import { readFile } from "node:fs/promises";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 
-const [workflow, plan, managedServices] = await Promise.all([
+const [workflow, plan, managedServices, edgeInventory] = await Promise.all([
   read(".github/workflows/kinecheck-disaster-recovery-v2.yml"),
   read("docs/continuidad/plan-recuperacion-kinecheck.md"),
   read("docs/continuidad/recuperacion-servicios-administrados.md"),
+  read("docs/continuidad/inventario-edge-functions-2026-08-30.md"),
 ]);
 
 const requireTokens = (source, tokens, label) => {
@@ -105,5 +106,24 @@ requireTokens(managedServices, [
   "8",
   "Diez",
 ], "checklist de servicios administrados");
+
+requireTokens(edgeInventory, [
+  "18 Edge Functions `ACTIVE`",
+  "ocho tienen fuente",
+  "diez no tienen fuente",
+  "automation-control",
+  "beta-password-once",
+  "dolor-lumbar-course-key",
+  "evidence-access",
+  "evidence-content",
+  "pain-content",
+  "pain-hotmart-webhook",
+  "platform-login",
+  "student-semester-intake",
+  "support-request",
+  "No copiar el cuerpo desde producción",
+  "No crear branches/proyectos Supabase con costo",
+  "fuente autorizada y trazable",
+], "inventario de Edge Functions");
 
 console.log("Disaster-recovery contract: PASS");

--- a/scripts/validate-disaster-recovery.mjs
+++ b/scripts/validate-disaster-recovery.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+const [workflow, plan, managedServices] = await Promise.all([
+  read(".github/workflows/kinecheck-disaster-recovery-v2.yml"),
+  read("docs/continuidad/plan-recuperacion-kinecheck.md"),
+  read("docs/continuidad/recuperacion-servicios-administrados.md"),
+]);
+
+const requireTokens = (source, tokens, label) => {
+  for (const token of tokens) {
+    assert.ok(source.includes(token), `${label}: falta ${token}`);
+  }
+};
+
+requireTokens(workflow, [
+  "image: postgres:17",
+  "postgres:17",
+  "pg_dump",
+  "--schema=public",
+  "pg_restore",
+  "--exit-on-error",
+  "restored-counts.json",
+  "manifest.json",
+  '"storage_objects_included": false',
+  '"auth_users_included": false',
+  "-aes-256-cbc",
+  "-pbkdf2",
+  "-iter 250000",
+  "openssl enc -d",
+  "expected_checksum",
+  "actual_checksum",
+  "Confirm plaintext removal",
+  "retention-days: 30",
+], "workflow v2");
+
+for (const relation of [
+  "course_access",
+  "hotmart_product_grants",
+  "hotmart_purchases",
+  "hotmart_webhook_events",
+  "kinecheck_access_policy",
+  "platform_feature_flags",
+  "platform_cases",
+  "platform_user_preferences",
+  "kinecheck_legal_acceptances",
+  "kinecheck_support_requests",
+  "kinecheck_restore_drills",
+]) {
+  assert.ok(workflow.includes(relation), `workflow v2: falta tabla crítica ${relation}`);
+}
+
+for (const routine of [
+  "process_hotmart_event",
+  "deactivate_expired_course_access",
+  "run_kinecheck_config_restore_drill",
+]) {
+  assert.ok(workflow.includes(routine), `workflow v2: falta función crítica ${routine}`);
+}
+
+assert.doesNotMatch(workflow, /set\s+-[^\n]*x/, "workflow v2 no debe habilitar trazas de shell");
+for (const line of workflow.split(/\r?\n/)) {
+  if (/echo/.test(line) && /\$\{?(?:SUPABASE_DB_URL|BACKUP_ENCRYPTION_PASSPHRASE)/.test(line)) {
+    assert.match(line, /::add-mask::/, "workflow v2 no debe imprimir secretos");
+  }
+}
+
+const uploadBlock = workflow.slice(
+  workflow.indexOf("- name: Upload encrypted recovery package"),
+  workflow.indexOf("- name: Write workflow summary"),
+);
+assert.ok(uploadBlock.length > 0, "workflow v2: falta bloque de upload");
+assert.doesNotMatch(
+  uploadBlock,
+  /kinecheck-public\.dump(?:\s|$)/m,
+  "el artefacto no debe incluir el dump sin cifrar",
+);
+assert.doesNotMatch(
+  uploadBlock,
+  /kinecheck-public\.dump\.sha256/,
+  "el artefacto no debe incluir la huella del dump sin cifrar",
+);
+
+requireTokens(plan, [
+  "KineCheck Disaster Recovery v2",
+  "PostgreSQL 17",
+  "kinecheck-public.dump.enc",
+  "restored-counts.json",
+  "Storage",
+  "Auth",
+  "no se puede cerrar",
+], "plan de recuperación");
+
+requireTokens(managedServices, [
+  "course-assets",
+  "Storage",
+  "Auth",
+  "Edge Functions",
+  "Cloudflare",
+  "DNS",
+  "nombres de secretos",
+  "18",
+  "8",
+  "Diez",
+], "checklist de servicios administrados");
+
+console.log("Disaster-recovery contract: PASS");


### PR DESCRIPTION
Prepara el cierre técnico de #10 sin cerrarlo: valida el contrato del workflow KineCheck Disaster Recovery v2, restaura con PostgreSQL 17, verifica manifiesto y conteos, prueba el cifrado antes de subir artifacts y bloquea cualquier dump sin cifrar. Añade procedimientos separados para Storage, Auth, Edge Functions, secretos y DNS/Cloudflare, además de evidencia actual de Supabase Advisors. No modifica Supabase ni crea recursos pagos. El backup externo continúa pendiente hasta configurar los dos Actions secrets y obtener una ejecución verde con restauración comprobada.