### PR TITLE
Prepare clean public schema before DR restore

### DIFF
--- a/.github/workflows/kinecheck-disaster-recovery-v2.yml
+++ b/.github/workflows/kinecheck-disaster-recovery-v2.yml
@@ -106,6 +106,16 @@ jobs:
           set -euo pipefail
           docker run --rm --network host \
             -e PGPASSWORD="$PGPASSWORD" \
+            postgres:17 \
+            psql \
+              --host=127.0.0.1 \
+              --port=5432 \
+              --username=postgres \
+              --dbname=kinecheck_restore \
+              --set=ON_ERROR_STOP=1 \
+              --command='DROP SCHEMA IF EXISTS public CASCADE;'
+          docker run --rm --network host \
+            -e PGPASSWORD="$PGPASSWORD" \
             -v "$PWD/disaster-recovery:/backup" \
             postgres:17 \
             pg_restore \

--- a/scripts/validate-disaster-recovery.mjs
+++ b/scripts/validate-disaster-recovery.mjs
@@ -61,6 +61,25 @@ for (const routine of [
   assert.ok(workflow.includes(routine), `workflow v2: falta función crítica ${routine}`);
 }
 
+const restoreBlock = workflow.slice(
+  workflow.indexOf("- name: Restore dump into temporary PostgreSQL 17"),
+  workflow.indexOf("- name: Validate restored application structure"),
+);
+assert.ok(restoreBlock.length > 0, "workflow v2: falta bloque de restauración PostgreSQL 17");
+requireTokens(restoreBlock, [
+  "postgres:17",
+  "psql",
+  "--dbname=kinecheck_restore",
+  "--set=ON_ERROR_STOP=1",
+  "DROP SCHEMA IF EXISTS public CASCADE;",
+  "pg_restore",
+  "--exit-on-error",
+], "restauración PostgreSQL 17");
+assert.ok(
+  restoreBlock.indexOf("DROP SCHEMA IF EXISTS public CASCADE;") < restoreBlock.indexOf("pg_restore"),
+  "la base temporal debe quedar sin public antes de pg_restore",
+);
+
 assert.doesNotMatch(workflow, /set\s+-[^\n]*x/, "workflow v2 no debe habilitar trazas de shell");
 for (const line of workflow.split(/\r?\n/)) {
   if (/echo/.test(line) && /\$\{?(?:SUPABASE_DB_URL|BACKUP_ENCRYPTION_PASSPHRASE)/.test(line)) {


### PR DESCRIPTION
Corrige el fallo real observado en el run 33346505140. Antes de pg_restore, elimina únicamente el schema public de la base temporal PostgreSQL 17 usando psql con ON_ERROR_STOP; mantiene pg_restore --exit-on-error, las validaciones estructurales, manifest, cifrado, verificación SHA, eliminación de plaintext y el upload condicionado a una restauración válida. Añade un test de contrato para impedir la regresión. No cierra #10: después del merge todavía se debe ejecutar manualmente el DR real y comprobar el artefacto cifrado y la restauración completa.