### PR TITLE
docs: add KineCheck funding readiness framework

### DIFF
--- a/docs/funding/FUNDING-READINESS-KINECHECK.md
+++ b/docs/funding/FUNDING-READINESS-KINECHECK.md
@@ -1,0 +1,894 @@
+# Funding Readiness KineCheck
+
+**Documento:** Fuente maestra para preparación de financiamiento público y aceleración  
+**Producto:** KineCheck  
+**Estado:** vigente como marco reutilizable de postulación  
+**Responsable:** Emmanuel Zúñiga  
+**Última actualización:** 3 de septiembre de 2026  
+**PRD relacionado:** `docs/PRD-KINECHECK.md`
+
+> Este documento no reemplaza las bases de una convocatoria. Su función es mantener una estructura común de KineCheck lista para ser adaptada a CORFO, Start-Up Chile, Sercotec, ANID, Gobierno Regional u otros instrumentos. Antes de cada postulación se deben volver a verificar bases, requisitos, montos, plazos, incompatibilidades, elegibilidad y anexos vigentes.
+
+---
+
+## 1. Objetivo
+
+Preparar KineCheck para postular a distintas fuentes de financiamiento sin reescribir el proyecto desde cero ni modificar artificialmente la naturaleza del producto para calzar con un fondo.
+
+La estrategia es separar:
+
+1. **núcleo invariable de KineCheck**;
+2. **evidencia reutilizable**;
+3. **proyecto financiable específico**;
+4. **capa de adaptación por instrumento**.
+
+---
+
+## 2. Regla de gobernanza
+
+Toda postulación debe ser consistente con:
+
+1. `legal/terminos.html` y `legal/privacidad.html`;
+2. `docs/brand-architecture.md`;
+3. `docs/PRD-KINECHECK.md`;
+4. configuración técnica y comercial vigente;
+5. evidencia real disponible.
+
+No se deben inventar usuarios, ventas, alianzas, validaciones, TRL, resultados, porcentajes de impacto, propiedad intelectual, patentes, instituciones asociadas ni métricas para mejorar una postulación.
+
+---
+
+## 3. Núcleo invariable de KineCheck
+
+### 3.1 Definición
+
+KineCheck es un ecosistema digital de **salud musculoesquelética** orientado a formación, aprendizaje, razonamiento y acceso a recursos educativos para estudiantes y profesionales.
+
+### 3.2 Problema central
+
+La formación, el razonamiento aplicado, las herramientas educativas y el acceso a contenidos musculoesqueléticos suelen estar fragmentados entre múltiples superficies, con recorridos de compra, acceso y aprendizaje poco integrados.
+
+### 3.3 Solución
+
+KineCheck integra:
+
+- sitio público;
+- catálogo por perfil;
+- compra mediante Hotmart;
+- autenticación y licencias;
+- Academy / Mi KineCheck;
+- cursos y aplicaciones educativas;
+- contenido premium protegido;
+- soporte y trazabilidad de acceso.
+
+Flujo de referencia:
+
+`Usuario → kinecheck.cl → producto → Hotmart → compra → backend/licencia → Academy → producto autorizado`
+
+### 3.4 Usuarios
+
+- Estudiantes.
+- Profesionales.
+- Instituciones educativas, clínicas u organizaciones como potencial línea B2B/B2B2C cuando exista una oferta formal para ese segmento.
+- Usuarios futuros de KineCheck Recupera únicamente cuando su arquitectura específica de privacidad y datos esté aprobada.
+
+### 3.5 Límites
+
+KineCheck no es:
+
+- ficha clínica institucional;
+- repositorio de pacientes;
+- sistema asistencial;
+- reemplazo del juicio profesional;
+- repositorio autorizado para datos identificables de pacientes en sus productos educativos actuales.
+
+---
+
+## 4. Relato maestro de financiamiento
+
+### 4.1 Frase de una línea
+
+**KineCheck es una plataforma digital de salud musculoesquelética que integra formación, razonamiento aplicado, acceso y herramientas educativas en una experiencia escalable para estudiantes y profesionales.**
+
+### 4.2 Versión breve
+
+KineCheck busca reducir la fragmentación entre aprendizaje, razonamiento aplicado y acceso a recursos musculoesqueléticos mediante una plataforma digital unificada. El producto combina experiencias educativas, control de licencias, Academy y contenidos especializados, manteniendo límites explícitos de privacidad y sin operar como ficha clínica. El financiamiento se utilizará para validar, escalar o desarrollar capacidades específicas según el instrumento postulado.
+
+### 4.3 Regla de adaptación
+
+El relato base no cambia. Lo que cambia es el énfasis:
+
+- **CORFO Inicia / Semilla:** innovación, MVP y validación inicial;
+- **CORFO Expande:** tracción, ventas, crecimiento y escalamiento;
+- **Start-Up Chile:** startup tecnológica, producto funcional, mercado y expansión internacional;
+- **Sercotec:** modelo de negocio, clientes, ventas, capacidades y ejecución comercial;
+- **ANID / Startup Ciencia:** I+D real, incertidumbre tecnológica, conocimiento nuevo y validación científico-tecnológica;
+- **GORE / FRPD / instrumentos regionales:** impacto regional, transferencia, beneficiarios, alianzas e indicadores territoriales.
+
+---
+
+## 5. Perfil maestro del postulante
+
+Antes de abrir cualquier postulación deben estar confirmados documentalmente:
+
+| Variable | Estado |
+|---|---|
+| Persona jurídica que postula | PENDIENTE DE CONSOLIDAR |
+| RUT postulante | PENDIENTE DE CONSOLIDAR |
+| Fecha inicio de actividades primera categoría | PENDIENTE DE CONSOLIDAR |
+| Giro(s) | PENDIENTE DE CONSOLIDAR |
+| Región tributaria / domicilio | PENDIENTE DE CONSOLIDAR |
+| Ventas netas últimos 12 meses | PENDIENTE DE CONSOLIDAR |
+| Ventas atribuibles específicamente a KineCheck | PENDIENTE DE CONSOLIDAR |
+| Número de clientes pagadores | PENDIENTE DE CONSOLIDAR |
+| Deudas tributarias/previsionales exigibles | VERIFICAR AL POSTULAR |
+| Relación con otras empresas | VERIFICAR AL POSTULAR |
+| Participación societaria | PENDIENTE DE CONSOLIDAR |
+| Representante legal | PENDIENTE DE CONSOLIDAR |
+
+Estas variables determinan elegibilidad para múltiples fondos y no deben inferirse.
+
+---
+
+## 6. Inventario de evidencia actual
+
+### 6.1 Verde — ya existe evidencia sólida
+
+- PRD maestro de KineCheck.
+- Arquitectura de marca.
+- Plataforma pública funcional.
+- Academy / Mi KineCheck.
+- Integración comercial con Hotmart.
+- Autenticación y licenciamiento.
+- Protección de contenido premium en componentes críticos.
+- Términos y Política de Privacidad.
+- KineCheck Estudiante activo.
+- Pilotos / beta y procesos de testeo.
+- QA automatizado y auditorías multidispositivo.
+- Arquitectura tecnológica documentable.
+- Evidencia de desarrollo continuo y control de versiones.
+
+### 6.2 Amarillo — existe, pero debe consolidarse
+
+- ventas reales;
+- clientes pagadores;
+- métricas de uso;
+- conversión visita → checkout → compra;
+- testimonios con consentimiento y trazabilidad;
+- alianzas académicas o clínicas;
+- propiedad intelectual y titularidad documental;
+- costos reales de operación;
+- dedicación del equipo;
+- roadmap comercial;
+- indicadores de soporte;
+- resultados del piloto de lanzamiento.
+
+### 6.3 Rojo — debe construirse antes de competir seriamente
+
+- TAM / SAM / SOM con metodología documentada;
+- análisis competitivo formal;
+- benchmark nacional e internacional;
+- línea base de impacto;
+- metas cuantificadas de impacto;
+- modelo financiero a 24–36 meses;
+- CAC, LTV y payback cuando exista base suficiente;
+- presupuesto estándar financiable;
+- Gantt reusable;
+- matriz de riesgos de proyecto;
+- cartas de apoyo / compromiso;
+- pitch estandarizado;
+- data room legal/tributario consolidado.
+
+---
+
+## 7. Estructura universal de una postulación KineCheck
+
+Todo proyecto de financiamiento debe poder responder, con evidencia, las siguientes secciones:
+
+### 7.1 Problema y oportunidad
+
+Debe contener:
+
+- problema concreto;
+- quién lo experimenta;
+- magnitud;
+- evidencia;
+- por qué las alternativas actuales son insuficientes;
+- costo o consecuencia del problema;
+- oportunidad de mercado o de impacto.
+
+### 7.2 Solución
+
+Debe mostrar:
+
+- qué es KineCheck;
+- qué parte del producto existe hoy;
+- qué parte se financiará;
+- experiencia del usuario;
+- diferenciadores;
+- demostración o evidencia funcional.
+
+### 7.3 Innovación
+
+Responder:
+
+- qué existe hoy;
+- qué hace KineCheck distinto;
+- si la innovación es de producto, proceso, modelo, tecnología o combinación;
+- barreras de copia;
+- conocimiento o activos propios;
+- por qué el avance propuesto no es solo desarrollo rutinario.
+
+### 7.4 Mercado
+
+Debe incluir:
+
+- cliente y usuario;
+- quién paga;
+- TAM;
+- SAM;
+- SOM;
+- tamaño y crecimiento del mercado;
+- competencia directa e indirecta;
+- sustitutos;
+- estrategia de entrada;
+- canales de adquisición.
+
+### 7.5 Validación y tracción
+
+Usar solo evidencia verificable:
+
+- testers;
+- pilotos;
+- usuarios activos;
+- clientes pagadores;
+- ventas;
+- recurrencia;
+- uso de Academy;
+- aperturas de productos;
+- feedback;
+- tasas de finalización cuando existan;
+- testimonios autorizados.
+
+### 7.6 Modelo de negocio
+
+Debe especificar:
+
+- oferta B2C actual;
+- productos individuales;
+- packs;
+- precios vigentes al momento de postular;
+- costos principales;
+- margen estimado si puede calcularse;
+- potencial B2B/B2B2C solo si existe una propuesta real;
+- recurrencia y expansión futura.
+
+### 7.7 Escalabilidad
+
+Explicar:
+
+- qué puede crecer sin aumentar costos proporcionalmente;
+- qué componentes requieren personas;
+- capacidad tecnológica;
+- automatización;
+- Chile → Latinoamérica si existe estrategia concreta;
+- localización de contenido;
+- soporte;
+- licenciamiento.
+
+### 7.8 Equipo
+
+Debe incluir:
+
+- experiencia relevante del fundador;
+- capacidades clínicas/docentes;
+- capacidades tecnológicas;
+- capacidades comerciales;
+- dedicación;
+- roles faltantes;
+- asesores o aliados verificables.
+
+### 7.9 Impacto
+
+Separar:
+
+- impacto educativo;
+- impacto económico;
+- impacto tecnológico;
+- impacto regional cuando corresponda;
+- impacto en productividad o acceso;
+- indicadores y metas.
+
+### 7.10 Plan de trabajo
+
+Cada objetivo específico debe conectar:
+
+`Objetivo → actividad → entregable → indicador → meta → fecha → responsable → costo`
+
+### 7.11 Presupuesto
+
+No solicitar fondos para “seguir mejorando la plataforma”. Cada gasto debe vincularse con una actividad y resultado.
+
+### 7.12 Sostenibilidad posterior
+
+Explicar cómo continúa el producto cuando termina el subsidio:
+
+- ventas;
+- reinversión;
+- nuevos clientes;
+- licencias;
+- alianzas;
+- expansión.
+
+---
+
+## 8. Proyecto financiable estándar
+
+### 8.1 Nombre base
+
+**Escalamiento y validación de una plataforma digital integrada de educación y razonamiento musculoesquelético para estudiantes y profesionales.**
+
+Este nombre es una base de trabajo; debe adaptarse a la convocatoria.
+
+### 8.2 Objetivo general base
+
+Validar y escalar las capacidades tecnológicas, comerciales y de adopción de KineCheck para ampliar el acceso a experiencias digitales de formación y razonamiento musculoesquelético, manteniendo seguridad, privacidad y trazabilidad de acceso.
+
+### 8.3 Objetivos específicos modulares
+
+Seleccionar solo los que correspondan al fondo:
+
+1. Validar demanda y disposición de pago en segmentos prioritarios.
+2. Mejorar la experiencia de acceso, continuidad y uso de productos digitales.
+3. Fortalecer la protección, observabilidad y escalabilidad tecnológica.
+4. Ejecutar pilotos institucionales o regionales.
+5. Consolidar estrategia comercial y canales de adquisición.
+6. Desarrollar una capacidad tecnológica nueva cuando exista incertidumbre técnica real.
+7. Medir resultados educativos o de adopción mediante indicadores predefinidos.
+8. Preparar expansión nacional o internacional.
+
+---
+
+## 9. Paquetes de trabajo reutilizables
+
+### WP1 — Validación de problema y mercado
+
+**Entregables:** estudio de usuarios, segmentación, benchmark, TAM/SAM/SOM, disposición de pago.
+
+### WP2 — Producto y tecnología
+
+**Entregables:** funcionalidades financiadas, seguridad, infraestructura, QA, documentación técnica.
+
+### WP3 — Pilotos y validación
+
+**Entregables:** pilotos, cohortes, indicadores de uso, aprendizaje, satisfacción y adopción.
+
+### WP4 — Comercialización
+
+**Entregables:** embudo, canales, experimentos de adquisición, estrategia B2C/B2B, materiales comerciales.
+
+### WP5 — Escalamiento
+
+**Entregables:** plan de expansión, automatización, capacidad operativa, alianzas, internacionalización cuando aplique.
+
+### WP6 — Gestión, medición e impacto
+
+**Entregables:** KPIs, línea base, seguimiento, riesgos, informe final y plan de continuidad.
+
+---
+
+## 10. Matriz de adaptación por instrumento
+
+| Instrumento | Debe enfatizar | KineCheck debe demostrar | Evitar |
+|---|---|---|---|
+| CORFO Inicia / Semilla | innovación + validación temprana | problema, solución, MVP, mercado y ausencia/condición de ventas exigida por bases | presentar una empresa demasiado madura como idea |
+| CORFO Expande | tracción + crecimiento | ventas elegibles, producto validado, equipo, expansión, mercado | esconder ventas o inflar crecimiento |
+| Start-Up Chile Ignite | startup + escalabilidad | producto funcional, validación, mercado grande, equipo, expansión internacional | relato local sin potencial de escala |
+| Sercotec Capital Semilla | creación de negocio | elegibilidad del postulante, Canvas, pitch, clientes, costos | postular si la empresa ya no cumple etapa de entrada |
+| Sercotec Crece | fortalecimiento de empresa | ventas, plan de negocio, inversión y mejora de competitividad | presentar I+D como eje principal si el fondo no lo exige |
+| ANID Startup Ciencia | EBCT / I+D | conocimiento nuevo, incertidumbre tecnológica, TRL verificable, equipo científico-tecnológico | llamar I+D a desarrollo web rutinario |
+| CORFO Crea y Valida | innovación tecnológica | desafío técnico, desarrollo, validación, mercado | financiar solo marketing o contenidos |
+| CORFO Innova Región | innovación + impacto territorial | problema regional, pilotos, empresas/usuarios beneficiarios, escalamiento | proyecto sin vínculo regional demostrable |
+| GORE / FRPD | impacto regional + transferencia | institución elegible, alianzas, beneficiarios, indicadores, transferencia | postular solo como emprendimiento comercial si las bases exigen ejecutor institucional |
+
+**Regla:** montos, porcentajes de cofinanciamiento, antigüedad, ventas mínimas/máximas, fechas y beneficiarios elegibles se verifican nuevamente en las bases oficiales vigentes antes de cada envío.
+
+---
+
+## 11. TAM / SAM / SOM
+
+### 11.1 TAM
+
+Mercado total teórico que podría utilizar una solución como KineCheck.
+
+Debe construirse desde fuentes oficiales o sectoriales y separar, cuando corresponda:
+
+- estudiantes de carreras de salud;
+- kinesiólogos/fisioterapeutas;
+- otros profesionales MSK;
+- instituciones educativas;
+- potencial internacional.
+
+### 11.2 SAM
+
+Parte del TAM alcanzable con la oferta actual, idioma, geografía, regulación y canales.
+
+### 11.3 SOM
+
+Participación realista que KineCheck puede capturar en 24–36 meses considerando capacidad comercial, CAC, conversión y recursos.
+
+### 11.4 Regla
+
+No calcular TAM multiplicando una población arbitraria por el precio más alto. Toda cifra debe indicar fuente, año, supuesto y fórmula.
+
+---
+
+## 12. Análisis competitivo
+
+Crear una matriz estándar con:
+
+| Competidor / alternativa | Segmento | Oferta | Precio | Fortalezas | Debilidades | Diferencia KineCheck | Fuente |
+|---|---|---|---|---|---|---|---|
+
+Incluir:
+
+- plataformas de cursos;
+- educación continua en salud;
+- aplicaciones de aprendizaje clínico;
+- recursos gratuitos;
+- formación universitaria/posgrado;
+- sustitutos indirectos.
+
+No afirmar que “no existe competencia”.
+
+---
+
+## 13. Tracción
+
+### 13.1 KPIs comerciales
+
+- visitas;
+- leads;
+- checkouts iniciados;
+- compras;
+- conversión;
+- ticket promedio;
+- ventas netas;
+- reembolsos;
+- clientes nuevos;
+- repetición de compra.
+
+### 13.2 KPIs de producto
+
+- usuarios registrados;
+- usuarios activos;
+- acceso exitoso;
+- productos abiertos;
+- tiempo hasta primer acceso;
+- progreso;
+- finalización;
+- errores de acceso;
+- tickets de soporte.
+
+### 13.3 KPIs de validación
+
+- testers reclutados;
+- testers que completan piloto;
+- satisfacción;
+- intención de recomendación solo si se mide formalmente;
+- problemas detectados;
+- mejoras implementadas.
+
+---
+
+## 14. Modelo financiero
+
+Construir un modelo mensual de al menos 24 meses con:
+
+- unidades vendidas por producto;
+- precio neto;
+- comisión/plataforma de pago;
+- costos tecnológicos;
+- costos de contenido;
+- marketing;
+- soporte;
+- equipo;
+- gastos legales/contables;
+- margen bruto;
+- resultado operativo;
+- caja;
+- aporte propio;
+- subsidio solicitado.
+
+Cuando exista suficiente historial agregar:
+
+- CAC;
+- LTV;
+- payback;
+- churn/retención cuando sea aplicable.
+
+---
+
+## 15. Presupuesto financiable estándar
+
+Cada línea debe vincularse a un objetivo y entregable.
+
+Categorías posibles, sujetas a las bases:
+
+- personal especializado;
+- desarrollo tecnológico;
+- servicios de validación;
+- diseño/UX;
+- estudios de mercado;
+- propiedad intelectual;
+- certificaciones;
+- infraestructura tecnológica;
+- pilotaje;
+- difusión/comercialización permitida;
+- asesorías especializadas;
+- viajes o internacionalización cuando sean elegibles.
+
+No comprometer gastos antes de revisar fecha de elegibilidad de cada convocatoria.
+
+---
+
+## 16. Impacto y línea base
+
+Toda meta debe tener:
+
+`Indicador + línea base + meta + fuente + frecuencia + responsable`
+
+Ejemplos de indicadores potenciales, solo si se medirán realmente:
+
+- tiempo desde compra a acceso funcional;
+- porcentaje de usuarios que logra acceder sin soporte;
+- finalización de módulos;
+- número de usuarios participantes en pilotos;
+- instituciones participantes;
+- satisfacción;
+- número de productos validados;
+- ventas;
+- nuevos mercados;
+- empleos o servicios especializados contratados;
+- adopción regional.
+
+---
+
+## 17. Alianzas
+
+Prioridades:
+
+1. universidades;
+2. escuelas/carreras de salud;
+3. clínicas o centros de rehabilitación;
+4. asociaciones profesionales;
+5. centros de innovación;
+6. entidades regionales;
+7. expertos en tecnología, educación o evidencia.
+
+Cada alianza debe clasificarse como:
+
+- carta de apoyo;
+- piloto;
+- beneficiario;
+- coejecutor;
+- proveedor;
+- asesor;
+- canal comercial;
+- institución patrocinante.
+
+No usar logos o nombres como alianza sin autorización.
+
+---
+
+## 18. Propiedad intelectual
+
+Consolidar:
+
+- titularidad de marca;
+- titularidad de código;
+- titularidad/licencias de contenidos;
+- imágenes y material de terceros;
+- contratos con colaboradores;
+- repositorios;
+- contenido premium;
+- dominios;
+- posibles registros de marca;
+- estrategia de secreto empresarial cuando corresponda.
+
+No presentar una patente como estrategia si no existe una invención patentable evaluada.
+
+---
+
+## 19. Data room de financiamiento
+
+Estructura recomendada:
+
+```text
+FUNDING-KINECHECK/
+├── 01_PRODUCTO/
+│   ├── PRD
+│   ├── arquitectura_marca
+│   └── demo_producto
+├── 02_LEGAL_TRIBUTARIO/
+│   ├── constitucion
+│   ├── vigencia
+│   ├── inicio_actividades
+│   ├── carpeta_tributaria
+│   └── declaraciones_requeridas
+├── 03_MERCADO/
+│   ├── problema_evidencia
+│   ├── TAM_SAM_SOM
+│   └── competencia
+├── 04_TRACCION/
+│   ├── ventas
+│   ├── usuarios
+│   ├── pilotos
+│   ├── metricas
+│   └── testimonios_autorizados
+├── 05_TECNOLOGIA/
+│   ├── arquitectura
+│   ├── seguridad
+│   ├── roadmap
+│   └── propiedad_intelectual
+├── 06_EQUIPO/
+│   ├── CV
+│   ├── roles
+│   └── dedicacion
+├── 07_ALIANZAS/
+│   └── cartas
+├── 08_FINANZAS/
+│   ├── modelo_24_36_meses
+│   ├── presupuesto
+│   └── cotizaciones
+├── 09_IMPACTO/
+│   ├── linea_base
+│   └── indicadores
+└── 10_POSTULACIONES/
+    ├── CORFO
+    ├── STARTUP_CHILE
+    ├── SERCOTEC
+    ├── ANID
+    └── GORE
+```
+
+El repositorio público no debe almacenar documentos tributarios, RUT, datos personales sensibles, secretos ni antecedentes financieros confidenciales. El data room debe mantenerse en un destino privado autorizado.
+
+---
+
+## 20. Pitch maestro
+
+### 20.1 Pitch de 40 segundos
+
+Debe responder:
+
+1. quiénes somos;
+2. problema;
+3. solución;
+4. evidencia de avance;
+5. qué buscamos.
+
+### 20.2 Pitch de 90 segundos
+
+Agregar:
+
+- cliente;
+- diferenciador;
+- tracción;
+- mercado;
+- uso del financiamiento.
+
+### 20.3 Pitch de 3–5 minutos
+
+Agregar:
+
+- producto/demo;
+- modelo de negocio;
+- competencia;
+- equipo;
+- roadmap;
+- indicadores;
+- monto y uso de fondos cuando corresponda.
+
+---
+
+## 21. Criterio de decisión de postulación
+
+Antes de dedicar tiempo a una convocatoria completar este gate:
+
+| Pregunta | Sí/No |
+|---|---|
+| ¿El postulante es elegible? | |
+| ¿La antigüedad cumple? | |
+| ¿Las ventas cumplen mínimo/máximo? | |
+| ¿La región cumple? | |
+| ¿La actividad económica cumple? | |
+| ¿KineCheck calza con el objetivo del instrumento? | |
+| ¿Existe evidencia suficiente para el criterio principal? | |
+| ¿Podemos aportar la contraparte? | |
+| ¿Los gastos que necesitamos son elegibles? | |
+| ¿Hay tiempo para completar anexos/cartas/cotizaciones? | |
+| ¿El proyecto puede ejecutarse en el plazo? | |
+| ¿La postulación no contradice otra subvención/incompatibilidad? | |
+
+Si falla una condición habilitante, no adaptar artificialmente el proyecto: descartar o esperar otra convocatoria.
+
+---
+
+## 22. Readiness por tipo de fondo
+
+### 22.1 CORFO Expande / aceleración
+
+**Readiness actual:** MEDIA-ALTA, condicionada a ventas y antigüedad elegibles.
+
+Falta consolidar:
+
+- ventas netas;
+- tracción;
+- mercado;
+- modelo financiero;
+- estrategia de expansión;
+- equipo y dedicación.
+
+### 22.2 Start-Up Chile
+
+**Readiness actual:** MEDIA-ALTA.
+
+Falta fortalecer:
+
+- mercado internacional;
+- tracción;
+- narrativa de escalabilidad;
+- equipo;
+- pitch en formato startup.
+
+### 22.3 Sercotec
+
+**Readiness actual:** DEPENDE DEL INSTRUMENTO.
+
+La principal variable es la elegibilidad legal/comercial de la persona o empresa postulante y el rango de ventas.
+
+### 22.4 ANID / Startup Ciencia
+
+**Readiness actual:** BAJA-MEDIA para el producto actual.
+
+Para competir seriamente se requeriría un componente de I+D genuino, con hipótesis tecnológica, incertidumbre, metodología y validación que vaya más allá de implementar una plataforma web educativa.
+
+### 22.5 GORE / FRPD
+
+**Readiness actual:** MEDIA para participar como socio/beneficiario tecnológico, condicionada a bases e institución ejecutora elegible.
+
+Falta:
+
+- alianza ejecutora;
+- impacto regional cuantificado;
+- beneficiarios;
+- cartas;
+- transferencia;
+- presupuesto y Gantt de mayor escala.
+
+---
+
+## 23. Plan de trabajo de preparación
+
+### Fase 1 — Identidad del postulante
+
+Cerrar:
+
+- entidad postulante;
+- inicio de actividades;
+- ventas;
+- situación tributaria;
+- propiedad de KineCheck.
+
+### Fase 2 — Mercado
+
+Construir:
+
+- problema con evidencia;
+- TAM/SAM/SOM;
+- competencia;
+- segmentación;
+- disposición de pago.
+
+### Fase 3 — Tracción
+
+Crear dashboard maestro de:
+
+- usuarios;
+- pilotos;
+- ventas;
+- conversión;
+- soporte;
+- progreso;
+- feedback.
+
+### Fase 4 — Finanzas
+
+Construir:
+
+- modelo 24–36 meses;
+- presupuesto modular;
+- contraparte disponible;
+- escenarios conservador/base/expansión.
+
+### Fase 5 — Impacto y alianzas
+
+Cerrar:
+
+- línea base;
+- indicadores;
+- cartas;
+- pilotos institucionales;
+- estrategia de transferencia.
+
+### Fase 6 — Pitch y anexos
+
+Preparar:
+
+- pitch 40 s;
+- pitch 90 s;
+- deck 5 min;
+- demo;
+- CV;
+- carpeta legal;
+- evidencia.
+
+---
+
+## 24. Definition of Ready para postular
+
+KineCheck está listo para enviar una postulación cuando:
+
+- elegibilidad confirmada contra bases vigentes;
+- problema respaldado con fuentes;
+- solución descrita sin contradicciones con PRD;
+- mercado cuantificado;
+- competencia documentada;
+- tracción respaldada;
+- presupuesto elegible y cotizado cuando corresponda;
+- contraparte disponible;
+- equipo y dedicación claros;
+- objetivos, actividades, hitos e indicadores alineados;
+- riesgos y mitigaciones definidos;
+- anexos completos;
+- pitch preparado;
+- revisión final sin cifras inventadas ni evidencia no verificable.
+
+---
+
+## 25. Próximos datos que deben consolidarse
+
+Prioridad alta:
+
+1. entidad/RUT que postulará;
+2. fecha de inicio de actividades;
+3. ventas netas últimos 12 meses;
+4. ventas de KineCheck por producto;
+5. clientes pagadores;
+6. métricas de tráfico y conversión;
+7. costos mensuales actuales;
+8. presupuesto que se desea financiar;
+9. dedicación disponible del fundador/equipo;
+10. posibles instituciones aliadas.
+
+Con esos diez datos se puede determinar de forma mucho más precisa qué fondos son realmente elegibles y cuál tiene mayor probabilidad de adjudicación.
+
+---
+
+## 26. Referencias internas
+
+- `docs/PRD-KINECHECK.md`
+- `docs/brand-architecture.md`
+- `legal/terminos.html`
+- `legal/privacidad.html`
+- `academy/config.js`
+- `#10` — Disaster Recovery
+- `#11` — conciliación Hotmart
+- `#106` — go-live follow-up
+- `#128` — protección de `main`
+- `#129` — paridad de `course-key`
+
+---
+
+**Regla final:** KineCheck debe calzar con un fondo porque el proyecto financiable y su evidencia cumplen el instrumento, no porque se cambie la historia del producto para satisfacer una pauta.


### PR DESCRIPTION
## Objetivo
Alinear KineCheck para futuras postulaciones a CORFO, Start-Up Chile, Sercotec, ANID, GORE/FRPD y otros instrumentos sin reescribir ni distorsionar el producto en cada convocatoria.

## Cambio
Agrega exclusivamente `docs/funding/FUNDING-READINESS-KINECHECK.md`.

El documento consolida:
- núcleo invariable de KineCheck alineado con `docs/PRD-KINECHECK.md`;
- relato maestro de financiamiento;
- perfil legal/comercial que debe confirmarse antes de postular;
- inventario de evidencia existente y brechas;
- estructura universal de postulación;
- proyecto financiable estándar y paquetes de trabajo;
- matriz de adaptación por tipo de fondo;
- metodología TAM/SAM/SOM y competencia;
- tracción, modelo financiero, presupuesto e impacto;
- alianzas y propiedad intelectual;
- estructura de data room privado;
- pitch de 40 s, 90 s y 3–5 min;
- gate de elegibilidad por convocatoria;
- readiness por tipo de fondo;
- plan de preparación y Definition of Ready.

## Reglas
- no se fijan como permanentes montos, fechas ni umbrales de fondos que puedan cambiar;
- cada convocatoria debe contrastarse nuevamente con bases oficiales vigentes;
- no se inventan ventas, alianzas, usuarios, TRL, impacto ni propiedad intelectual;
- documentos tributarios, datos personales, secretos y finanzas confidenciales deben mantenerse fuera del repositorio público.

## Alcance
Documentación solamente. No cambia código, producción, precios, Hotmart, Supabase, autenticación ni licencias.