### PR TITLE
docs: add institutional integration roadmap

### DIFF
--- a/docs/funding/README.md
+++ b/docs/funding/README.md
@@ -18,6 +18,9 @@ Esta carpeta separa la **verdad del producto** de la **evidencia de una postulac
 | `BUDGET-AND-PROJECT-PLAN.md` | Presupuesto modular, paquetes de trabajo, Gantt de 12 meses y riesgos. |
 | `ALLIANCE-PIPELINE.md` | Instituciones candidatas, rol esperado, evidencia de encaje y estado real de cada vínculo. |
 | `PITCH-KINECHECK.md` | Pitch maestro en versiones de 40 s, 90 s y 3–5 min. |
+| `UOH-PILOT-DISCOVERY.md` | Ficha de descubrimiento para explorar un piloto con UOH sin afirmar una alianza ni integración inexistente. |
+| `../integrations/INSTITUTIONAL-INTEGRATION-ROADMAP.md` | Roadmap B2B/B2B2C para cohortes, SSO, LTI/API y analítica institucional. |
+| `../integrations/INSTITUTIONAL-API-DRAFT.md` | Contrato conceptual de una futura API institucional; no desplegado. |
 
 ## Estado de las brechas
 
@@ -34,6 +37,8 @@ Esta carpeta separa la **verdad del producto** de la **evidencia de una postulac
 | Riesgos | **Matriz base creada**. |
 | Impacto | **Línea base y protocolo de medición creados**; no se declara eficacia educativa aún. |
 | Alianzas | **Pipeline de candidatos creado**; ninguna se presenta como comprometida sin carta o convenio. |
+| Integración institucional | **Roadmap creado**; API/LTI/SSO institucional siguen sin implementación y requieren descubrimiento con una institución real. |
+| UOH | **Ficha de descubrimiento creada**; no existe todavía alianza, piloto autorizado ni integración técnica. |
 | Pitch | **Versiones reutilizables creadas**. |
 | Persona jurídica/RUT/inicio SII/giro/ventas tributarias | **Hard gate pendiente**: requiere documentación del postulante, no se infiere desde fuentes públicas. |
 

--- a/docs/funding/UOH-PILOT-DISCOVERY.md
+++ b/docs/funding/UOH-PILOT-DISCOVERY.md
@@ -1,0 +1,155 @@
+# KineCheck × UOH — ficha de descubrimiento para piloto institucional
+
+**Estado:** preparación interna; NO existe alianza formal ni integración UOH activa  
+**Fecha:** 3 de septiembre de 2026  
+**Objetivo:** preparar una conversación seria con la Universidad de O'Higgins sin prometer capacidades que todavía no existen.
+
+## 1. Propósito de la conversación
+
+Explorar si existe interés académico e institucional en realizar un piloto controlado de KineCheck y determinar qué nivel de integración sería realmente necesario.
+
+La primera reunión NO busca cerrar un convenio tecnológico ni vender una integración terminada.
+
+## 2. Propuesta de piloto base
+
+Piloto académico de KineCheck con una cohorte acotada de estudiantes de Kinesiología.
+
+Características de referencia:
+- acceso temporal y controlado;
+- uno o dos productos KineCheck definidos previamente;
+- casos exclusivamente ficticios, simulados o anonimizados;
+- métricas de adopción y uso;
+- instrumento pre/post o encuesta final previamente definida;
+- informe de resultados;
+- sin obligación de compra posterior;
+- sin integrar sistemas UOH en la fase inicial salvo requerimiento explícito.
+
+Los números exactos de participantes y duración deben acordarse con la Universidad antes de documentarse como compromiso.
+
+## 3. Preguntas académicas
+
+1. ¿Qué problema formativo concreto debería intentar resolver o apoyar el piloto?
+2. ¿En qué asignatura, nivel o actividad tendría mejor encaje?
+3. ¿Qué producto KineCheck sería pertinente?
+4. ¿El uso sería obligatorio, voluntario o complementario?
+5. ¿Qué resultado tendría valor para el equipo académico?
+6. ¿Qué evidencia sería suficiente para decidir continuidad?
+7. ¿Se requiere aprobación ética o institucional para la evaluación del piloto?
+8. ¿Qué datos pueden recopilarse legítimamente y cuáles no?
+
+## 4. Preguntas técnicas
+
+No asumir respuestas.
+
+1. ¿Qué LMS o aula virtual utiliza la UOH para el contexto del piloto?
+2. ¿Es necesaria integración con el LMS en la primera fase?
+3. ¿Qué sistema de identidad institucional se utiliza?
+4. ¿Aceptan cuentas KineCheck independientes para un piloto inicial?
+5. ¿Existe interés futuro en SSO?
+6. ¿Existe interés futuro en LTI 1.3/LTI Advantage u otro estándar?
+7. ¿La institución necesita administrar cohortes directamente?
+8. ¿Qué reportes necesitaría recibir un docente/coordinador?
+9. ¿Necesita datos individuales o bastan agregados?
+10. ¿Existe un área TI/seguridad que deba revisar el producto antes del piloto?
+
+## 5. Preguntas de privacidad y gobernanza
+
+1. ¿Quién sería responsable de la selección de participantes?
+2. ¿Qué datos de identificación serían estrictamente necesarios?
+3. ¿Se puede operar con correo institucional o identificador pseudonimizado?
+4. ¿Qué plazo de retención sería aceptable?
+5. ¿Quién puede acceder a reportes?
+6. ¿Se requiere acuerdo de tratamiento de datos u otro instrumento?
+7. ¿Qué procedimiento debe seguirse para retiro de un participante?
+8. ¿Cómo se gestionará soporte durante el piloto?
+
+## 6. Alternativas de integración por etapa
+
+### Opción A — Piloto independiente
+
+La más rápida y recomendada inicialmente.
+
+- cuentas/accesos KineCheck;
+- Academy;
+- sin acceso al LMS;
+- métricas agregadas;
+- reporte final.
+
+### Opción B — Cohortes institucionales
+
+Si la UOH requiere administración propia:
+- cohorte;
+- altas/bajas;
+- licencias institucionales;
+- panel o flujo administrativo;
+- reportes agregados.
+
+### Opción C — Integración LMS/SSO
+
+Solo después de validar necesidad:
+- SSO institucional;
+- LTI u otro estándar compatible;
+- deep linking;
+- eventual retorno de progreso o resultados si existe justificación y acuerdo.
+
+## 7. Información que KineCheck debe llevar a la reunión
+
+- PRD maestro;
+- ficha ejecutiva de 1 página;
+- demo funcional;
+- arquitectura de privacidad;
+- estado real del producto;
+- propuesta de piloto;
+- métricas que pueden medirse;
+- roadmap institucional;
+- límites claros de lo que todavía no está implementado.
+
+## 8. Información que NO debe afirmarse
+
+Hasta existir evidencia documental, no decir:
+- “KineCheck está integrado con la UOH”;
+- “la UOH es partner de KineCheck”;
+- “KineCheck funciona con el LMS de la UOH”;
+- “la UOH validó KineCheck”;
+- “KineCheck tiene SSO universitario”;
+- “KineCheck tiene LTI implementado”.
+
+## 9. Resultados posibles de la primera reunión
+
+### Nivel 0
+Sin interés o sin encaje actual.
+
+### Nivel 1
+Interés exploratorio y solicitud de más antecedentes.
+
+### Nivel 2
+Acuerdo para diseñar un piloto.
+
+### Nivel 3
+Autorización/compromiso escrito para ejecutar piloto.
+
+### Nivel 4
+Piloto ejecutado e informe emitido.
+
+### Nivel 5
+Carta de apoyo, convenio, proyecto conjunto o futura integración institucional.
+
+No saltar del Nivel 1 al 5 en documentación de financiamiento.
+
+## 10. Gate para desarrollo técnico
+
+No desarrollar API, LTI, SSO ni panel institucional específico para UOH hasta que exista al menos:
+- contraparte académica identificada;
+- necesidad validada;
+- requerimiento técnico claro;
+- contraparte TI cuando corresponda;
+- definición de datos y privacidad;
+- alcance del piloto acordado.
+
+## 11. Formulación para fondos
+
+Mientras no exista acuerdo firmado, usar:
+
+**“KineCheck contempla como línea de escalamiento la interoperabilidad con instituciones educativas mediante gestión de cohortes, SSO, APIs y estándares LMS. Esta capacidad se encuentra en fase de diseño y descubrimiento institucional.”**
+
+Una vez exista carta o piloto autorizado, actualizar el lenguaje según la evidencia real disponible.

--- a/docs/integrations/INSTITUTIONAL-API-DRAFT.md
+++ b/docs/integrations/INSTITUTIONAL-API-DRAFT.md
@@ -1,0 +1,156 @@
+# KineCheck Institutional API — contrato conceptual
+
+**Estado:** borrador de diseño; NO desplegado  
+**Fecha:** 3 de septiembre de 2026  
+**Relacionado:** `INSTITUTIONAL-INTEGRATION-ROADMAP.md`
+
+> Este documento describe capacidades y recursos posibles. No define endpoints productivos ni autoriza integraciones con terceros.
+
+## 1. Objetivo
+
+Tener un contrato conceptual reutilizable para conversaciones técnicas con universidades u organizaciones antes de implementar una API institucional.
+
+## 2. Recursos conceptuales
+
+### Institution
+Representa una organización autorizada.
+
+Campos conceptuales:
+- `institution_id`
+- `display_name`
+- `status`
+- `allowed_products`
+- `contract_start`
+- `contract_end`
+
+### Cohort
+Grupo de usuarios asociado a una actividad o periodo.
+
+Campos conceptuales:
+- `cohort_id`
+- `institution_id`
+- `name`
+- `starts_at`
+- `ends_at`
+- `status`
+
+### Membership
+Vincula una persona con una cohorte.
+
+Campos mínimos:
+- identificador institucional pseudonimizado o correo institucional, según acuerdo;
+- estado;
+- fecha de alta/baja.
+
+### Entitlement
+Permiso para utilizar un producto.
+
+Campos conceptuales:
+- `product_slug`
+- `active`
+- `starts_at`
+- `expires_at`
+- `source=institutional`
+
+### LearningProgress
+Solo cuando el producto lo soporte y exista autorización para compartirlo.
+
+Campos posibles:
+- `product_slug`
+- `progress_percent`
+- `completed_units`
+- `last_activity_at`
+- `completion_status`
+
+## 3. Operaciones potenciales
+
+### Cohortes
+- crear cohorte;
+- consultar cohorte;
+- cerrar cohorte;
+- listar participantes autorizados.
+
+### Participantes
+- alta;
+- activación;
+- revocación;
+- consulta de estado.
+
+### Licencias
+- asignar producto;
+- consultar entitlement;
+- expirar/revocar entitlement.
+
+### Analítica
+- resumen agregado por cohorte;
+- adopción;
+- progreso agregado;
+- finalización agregada;
+- incidencias agregadas.
+
+## 4. Operaciones que NO deben formar parte de una primera versión
+
+- acceso directo a tablas de Supabase;
+- lectura de datos clínicos;
+- endpoints que permitan consultar usuarios arbitrarios;
+- exportaciones masivas sin scope institucional;
+- retorno de notas o calificaciones antes de acordar semántica, base jurídica y seguridad;
+- modificación de contenido premium;
+- administración global de KineCheck por parte de terceros.
+
+## 5. Autenticación futura
+
+La API institucional, si se implementa, debe usar credenciales machine-to-machine independientes por institución y con mínimo privilegio.
+
+Requisitos mínimos:
+- secretos fuera del frontend;
+- rotación/revocación;
+- scopes;
+- expiración cuando corresponda;
+- rate limit;
+- logging/auditoría;
+- bloqueo por institución.
+
+## 6. Scopes conceptuales
+
+Ejemplos, sujetos a diseño definitivo:
+- `cohorts:read`
+- `cohorts:write`
+- `members:read`
+- `members:write`
+- `entitlements:read`
+- `entitlements:write`
+- `analytics:read`
+
+No crear scopes de datos que KineCheck no necesita tratar.
+
+## 7. Respuestas y privacidad
+
+La API debería retornar el mínimo de información requerido. Siempre que sea posible:
+- usar identificadores internos o pseudónimos;
+- no devolver nombre completo;
+- no devolver información de pacientes;
+- no incluir query strings ni metadatos innecesarios en analítica;
+- separar reportes agregados de consultas individualizadas.
+
+## 8. Versionado
+
+Si se implementa:
+- contrato versionado (`v1`, `v2`, etc.);
+- cambios incompatibles requieren nueva versión;
+- documentación de deprecación;
+- pruebas de contrato automatizadas.
+
+## 9. Criterios para convertir este borrador en OpenAPI
+
+No generar especificación OpenAPI productiva hasta conocer:
+- institución piloto;
+- sistema institucional;
+- requerimientos de identidad;
+- campos mínimos;
+- operaciones requeridas;
+- reglas de privacidad;
+- modelo contractual;
+- responsables de soporte.
+
+Después de ese descubrimiento se puede generar un `openapi.yaml` real, validarlo contra seguridad y recién entonces implementar una API.

--- a/docs/integrations/INSTITUTIONAL-INTEGRATION-ROADMAP.md
+++ b/docs/integrations/INSTITUTIONAL-INTEGRATION-ROADMAP.md
@@ -1,0 +1,244 @@
+# KineCheck — Roadmap de Integración Institucional
+
+**Estado:** roadmap aprobado para exploración; no implementado en producción  
+**Fecha:** 3 de septiembre de 2026  
+**Documento rector:** `docs/PRD-KINECHECK.md`
+
+## 1. Objetivo
+
+Definir cómo KineCheck puede evolucionar desde su operación B2C actual hacia una capa institucional B2B/B2B2C interoperable con universidades, centros formadores y organizaciones, sin comprometer privacidad, seguridad ni la arquitectura actual de licencias.
+
+Este documento NO afirma que KineCheck ya tenga integración institucional, LTI, SAML, OIDC ni conexión con el LMS de ninguna universidad.
+
+## 2. Punto de partida real
+
+KineCheck ya dispone de capacidades técnicas reutilizables:
+
+- backend sobre Supabase y Edge Functions;
+- autenticación y resolución de licencias;
+- webhooks comerciales;
+- Academy como entrada autenticada canónica;
+- SSO/handoff controlado para KineCheck Estudiante;
+- métricas técnicas minimizadas;
+- contenido premium servido mediante mecanismos protegidos.
+
+Estas capacidades son la base para una futura capa institucional, pero no equivalen todavía a una API pública para terceros.
+
+## 3. Modelo objetivo
+
+```text
+Institución / LMS / Sistema de identidad
+              │
+              ▼
+   KineCheck Institutional Layer
+      ├── Identity / SSO
+      ├── Cohort provisioning
+      ├── Entitlements
+      ├── Progress / learning events
+      ├── Aggregated analytics
+      └── Audit / support
+              │
+              ▼
+        Academy + productos
+```
+
+## 4. Capacidades institucionales candidatas
+
+### 4.1 Provisioning de cohortes
+
+Permitir que una institución autorizada gestione cohortes sin depender de checkout individual.
+
+Capacidades potenciales:
+- alta de cohorte;
+- asignación de producto/licencia;
+- activación y expiración;
+- baja/revocación;
+- importación controlada por lote;
+- trazabilidad de cambios.
+
+### 4.2 Entitlements
+
+Resolver de forma segura qué productos puede usar una persona.
+
+Reglas:
+- la fuente de autorización debe permanecer en servidor;
+- nunca confiar en parámetros de URL como fuente de permiso;
+- mantener producto, vigencia y estado de licencia separados de la interfaz.
+
+### 4.3 SSO institucional
+
+Opciones a evaluar según la infraestructura del socio:
+- OIDC;
+- SAML;
+- LTI 1.3 / LTI Advantage para integración con LMS;
+- handoff propietario solo cuando un estándar no sea viable.
+
+No se seleccionará un mecanismo antes de conocer el entorno real de la institución.
+
+### 4.4 Progress / learning events
+
+Potencialmente exponer solo información educativa necesaria:
+- producto/curso;
+- módulos o hitos completados;
+- porcentaje de progreso si el producto lo soporta;
+- timestamps de actividad;
+- resultado de una evaluación educativa cuando exista base y autorización para compartirlo.
+
+Nunca incluir datos clínicos de pacientes reales.
+
+### 4.5 Analytics institucional
+
+Por defecto, priorizar información agregada:
+- usuarios activados;
+- usuarios activos;
+- sesiones;
+- aperturas de cursos;
+- avance agregado;
+- finalización;
+- incidencias técnicas;
+- métricas de adopción.
+
+La institución no debe recibir más datos personales que los estrictamente necesarios para la finalidad acordada.
+
+## 5. Principios de privacidad y seguridad
+
+1. Minimización de datos.
+2. Separación entre identidad, licencia, progreso y contenido premium.
+3. Autorización server-side.
+4. Credenciales institucionales almacenadas como secretos, nunca en frontend ni repositorio público.
+5. Scopes/permisos por institución.
+6. Registro auditable de altas, revocaciones y accesos administrativos.
+7. Rate limiting y controles antiabuso antes de exponer endpoints institucionales.
+8. Versionado explícito de contrato de API.
+9. Revocación de credenciales por institución.
+10. No reutilizar datos educativos para fines distintos sin base y aviso correspondiente.
+
+## 6. Fases de implementación
+
+### Fase 0 — Descubrimiento institucional
+
+No requiere desarrollo.
+
+Entregables:
+- LMS utilizado;
+- sistema de identidad;
+- responsables TI;
+- responsables académicos;
+- tipo de piloto;
+- necesidad o no de SSO;
+- información que el docente necesita ver;
+- restricciones de protección de datos;
+- reglas de retención y soporte.
+
+### Fase 1 — Piloto sin integración profunda
+
+Objetivo: validar adopción antes de construir infraestructura específica.
+
+Capacidades:
+- cohorte gestionada manualmente o por importación segura;
+- accesos institucionales temporales;
+- Academy actual;
+- métricas agregadas;
+- informe de piloto.
+
+### Fase 2 — Administración institucional
+
+- panel de cohortes;
+- roles institucionales;
+- provisioning/revocación;
+- reportes agregados;
+- auditoría.
+
+### Fase 3 — Integración de identidad/LMS
+
+Solo si existe requerimiento validado:
+- SSO institucional;
+- LTI 1.3 / LTI Advantage o estándar equivalente;
+- deep linking a actividades/productos cuando aplique;
+- retorno de resultados educativos solo cuando exista acuerdo y soporte técnico adecuado.
+
+### Fase 4 — API institucional versionada
+
+- contrato estable;
+- documentación;
+- autenticación machine-to-machine;
+- scopes;
+- sandbox;
+- monitoreo;
+- SLA solo si se define formalmente.
+
+## 7. Arquitectura comercial objetivo
+
+### B2C actual
+
+`Persona → Hotmart → licencia → Academy → producto`
+
+### B2B institucional básico
+
+`Institución → acuerdo/licencias → cohorte → Academy → producto`
+
+### B2B integrado
+
+`LMS/IdP institucional ↔ capa institucional KineCheck ↔ Academy/productos`
+
+Hotmart no tiene que ser necesariamente el mecanismo de provisioning institucional; esa decisión dependerá del modelo contractual futuro.
+
+## 8. Qué NO construir todavía
+
+Hasta completar descubrimiento con una institución real, no se debe:
+
+- desarrollar integración específica con un LMS supuesto;
+- implementar SAML/OIDC/LTI sin requerimiento;
+- exponer endpoints de progreso a terceros;
+- crear credenciales institucionales productivas;
+- publicar datos de estudiantes;
+- prometer interoperabilidad ya existente;
+- comprometer retornos de notas al LMS.
+
+## 9. Uso en financiamiento
+
+La capa institucional puede formularse como capacidad financiable si la convocatoria permite desarrollo tecnológico, adopción o transferencia.
+
+Componentes financiables potenciales:
+- gestión de cohortes;
+- interoperabilidad;
+- SSO/LTI;
+- panel institucional;
+- analítica educativa agregada;
+- seguridad y auditoría;
+- pilotos con organizaciones;
+- documentación y escalamiento B2B/B2B2C.
+
+Debe presentarse como roadmap o desarrollo propuesto mientras no exista implementación comprobada.
+
+## 10. Criterios de éxito
+
+Una fase institucional solo avanza si cumple:
+
+- problema institucional confirmado;
+- responsable académico y técnico identificados;
+- base de datos mínima definida;
+- requerimientos de privacidad acordados;
+- integración técnicamente viable;
+- piloto con indicadores predefinidos;
+- costo de integración justificable;
+- evidencia de uso/adopción suficiente para justificar la fase siguiente.
+
+## 11. Definition of Ready para desarrollo
+
+Antes de escribir código de integración institucional deben estar respondidas:
+
+1. ¿Qué institución participa?
+2. ¿Qué LMS usa?
+3. ¿Qué sistema de identidad usa?
+4. ¿Qué usuarios participan?
+5. ¿Qué productos KineCheck usarán?
+6. ¿Quién administra la cohorte?
+7. ¿Qué datos debe recibir la institución?
+8. ¿Qué datos NO debe recibir?
+9. ¿Se necesita SSO?
+10. ¿Se necesita retorno de progreso/notas?
+11. ¿Cuánto dura el piloto?
+12. ¿Qué éxito justifica escalar?
+
+Mientras estas respuestas no existan, el estado correcto es **roadmap**, no desarrollo productivo.


### PR DESCRIPTION
## Objetivo
Formalizar la evolución institucional de KineCheck sin afirmar capacidades aún no implementadas ni una alianza UOH inexistente.

## Cambios
- agrega `docs/integrations/INSTITUTIONAL-INTEGRATION-ROADMAP.md`;
- agrega `docs/integrations/INSTITUTIONAL-API-DRAFT.md`;
- agrega `docs/funding/UOH-PILOT-DISCOVERY.md`;
- actualiza `docs/funding/README.md` para enlazar estas fuentes.

## Contenido
- arquitectura objetivo B2B/B2B2C;
- cohort provisioning, entitlements, analytics y SSO;
- LTI 1.3/LTI Advantage, OIDC y SAML como opciones a evaluar, no como funcionalidades existentes;
- fases desde piloto independiente hasta integración LMS/API;
- límites de privacidad y seguridad;
- Definition of Ready antes de escribir código institucional;
- contrato conceptual de API, sin endpoints productivos;
- ficha de descubrimiento específica para UOH con preguntas académicas, técnicas y de gobernanza;
- lenguaje correcto para fondos mientras no exista carta, piloto o integración real.

## Alcance
Documentación únicamente. No modifica producción, Supabase, Hotmart, autenticación, licencias, precios ni endpoints productivos.